### PR TITLE
Add Google OAuth integration.

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -25,4 +25,10 @@ export const authApi = {
   logout: async (): Promise<void> => {
     await apiClient.post('/auth/logout');
   },
+
+  getGoogleAuthUrl: (): string => {
+    const baseUrl =
+      import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/';
+    return `${baseUrl}/oauth2/authorization/google`;
+  },
 };

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -68,3 +68,11 @@ export function useLogout() {
     },
   });
 }
+
+export function useGoogleLogin() {
+  return {
+    initiateGoogleLogin: () => {
+      window.location.href = authApi.getGoogleAuthUrl();
+    },
+  };
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as PublicRouteRouteImport } from './routes/_public/route'
 import { Route as ProtectedRouteRouteImport } from './routes/_protected/route'
 import { Route as AuthRouteRouteImport } from './routes/_auth/route'
 import { Route as PublicIndexRouteImport } from './routes/_public/index'
+import { Route as Oauth2RedirectRouteImport } from './routes/oauth2/redirect'
 import { Route as PublicDocsRouteImport } from './routes/_public/docs'
 import { Route as ProtectedDashboardRouteImport } from './routes/_protected/dashboard'
 import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
@@ -38,6 +39,11 @@ const PublicIndexRoute = PublicIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => PublicRouteRoute,
+} as any)
+const Oauth2RedirectRoute = Oauth2RedirectRouteImport.update({
+  id: '/oauth2/redirect',
+  path: '/oauth2/redirect',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PublicDocsRoute = PublicDocsRouteImport.update({
   id: '/docs',
@@ -89,6 +95,7 @@ export interface FileRoutesByFullPath {
   '/register': typeof AuthRegisterRoute
   '/dashboard': typeof ProtectedDashboardRoute
   '/docs': typeof PublicDocsRoute
+  '/oauth2/redirect': typeof Oauth2RedirectRoute
   '/': typeof PublicIndexRoute
   '/organizations/$orgId': typeof ProtectedOrganizationsOrgIdRoute
   '/projects/$projectId': typeof ProtectedProjectsProjectIdRoute
@@ -100,6 +107,7 @@ export interface FileRoutesByTo {
   '/register': typeof AuthRegisterRoute
   '/dashboard': typeof ProtectedDashboardRoute
   '/docs': typeof PublicDocsRoute
+  '/oauth2/redirect': typeof Oauth2RedirectRoute
   '/': typeof PublicIndexRoute
   '/organizations/$orgId': typeof ProtectedOrganizationsOrgIdRoute
   '/projects/$projectId': typeof ProtectedProjectsProjectIdRoute
@@ -115,6 +123,7 @@ export interface FileRoutesById {
   '/_auth/register': typeof AuthRegisterRoute
   '/_protected/dashboard': typeof ProtectedDashboardRoute
   '/_public/docs': typeof PublicDocsRoute
+  '/oauth2/redirect': typeof Oauth2RedirectRoute
   '/_public/': typeof PublicIndexRoute
   '/_protected/organizations/$orgId': typeof ProtectedOrganizationsOrgIdRoute
   '/_protected/projects/$projectId': typeof ProtectedProjectsProjectIdRoute
@@ -128,6 +137,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/dashboard'
     | '/docs'
+    | '/oauth2/redirect'
     | '/'
     | '/organizations/$orgId'
     | '/projects/$projectId'
@@ -139,6 +149,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/dashboard'
     | '/docs'
+    | '/oauth2/redirect'
     | '/'
     | '/organizations/$orgId'
     | '/projects/$projectId'
@@ -153,6 +164,7 @@ export interface FileRouteTypes {
     | '/_auth/register'
     | '/_protected/dashboard'
     | '/_public/docs'
+    | '/oauth2/redirect'
     | '/_public/'
     | '/_protected/organizations/$orgId'
     | '/_protected/projects/$projectId'
@@ -164,6 +176,7 @@ export interface RootRouteChildren {
   AuthRouteRoute: typeof AuthRouteRouteWithChildren
   ProtectedRouteRoute: typeof ProtectedRouteRouteWithChildren
   PublicRouteRoute: typeof PublicRouteRouteWithChildren
+  Oauth2RedirectRoute: typeof Oauth2RedirectRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -195,6 +208,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof PublicIndexRouteImport
       parentRoute: typeof PublicRouteRoute
+    }
+    '/oauth2/redirect': {
+      id: '/oauth2/redirect'
+      path: '/oauth2/redirect'
+      fullPath: '/oauth2/redirect'
+      preLoaderRoute: typeof Oauth2RedirectRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_public/docs': {
       id: '/_public/docs'
@@ -307,6 +327,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthRouteRoute: AuthRouteRouteWithChildren,
   ProtectedRouteRoute: ProtectedRouteRouteWithChildren,
   PublicRouteRoute: PublicRouteRouteWithChildren,
+  Oauth2RedirectRoute: Oauth2RedirectRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/_auth/login.tsx
+++ b/src/routes/_auth/login.tsx
@@ -24,6 +24,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { handleApiError } from '@/api/client';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { useGoogleLogin } from '@/hooks/use-auth';
 
 export const Route = createFileRoute('/_auth/login')({
   component: LoginPage,
@@ -38,6 +39,7 @@ type LoginForm = z.infer<typeof loginSchema>;
 
 function LoginPage() {
   const { login, isAuthenticated } = useAuth();
+  const { initiateGoogleLogin } = useGoogleLogin();
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -78,6 +80,39 @@ function LoginPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {/* Google Sign In Button */}
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full gap-2"
+            onClick={initiateGoogleLogin}
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="currentColor"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="currentColor"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="currentColor"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            Continue with Google
+          </Button>
+
+          <div className="relative flex justify-center text-xs uppercase mt-4">
+            <span className="bg-card px-2 text-muted-foreground">
+              Or continue with email
+            </span>
+          </div>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField

--- a/src/routes/_auth/register.tsx
+++ b/src/routes/_auth/register.tsx
@@ -24,6 +24,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 import { handleApiError } from '@/api/client';
 import { useEffect, useState } from 'react';
+import { useGoogleLogin } from '@/hooks/use-auth';
 
 export const Route = createFileRoute('/_auth/register')({
   component: RegisterPage,
@@ -50,6 +51,7 @@ type RegisterForm = z.infer<typeof registerSchema>;
 
 function RegisterPage() {
   const { register, isAuthenticated } = useAuth();
+  const { initiateGoogleLogin } = useGoogleLogin();
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -94,6 +96,39 @@ function RegisterPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {/* Google Sign In Button */}
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full gap-2"
+            onClick={initiateGoogleLogin}
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="currentColor"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="currentColor"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="currentColor"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            Continue with Google
+          </Button>
+          <div className="relative flex justify-center text-xs uppercase mt-4">
+            <span className="bg-card px-2 text-muted-foreground">
+              Or continue with email
+            </span>
+          </div>
+
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField

--- a/src/routes/oauth2/redirect.tsx
+++ b/src/routes/oauth2/redirect.tsx
@@ -1,0 +1,44 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { authApi } from '@/api/auth';
+import { CURRENT_USER_KEY } from '@/hooks/use-auth';
+import { toast } from 'sonner';
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
+
+export const Route = createFileRoute('/oauth2/redirect')({
+  validateSearch: (search: Record<string, any>) => ({
+    access_token: search.access_token as string | undefined,
+    error: search.error as string | undefined,
+  }),
+
+  beforeLoad: async ({ search, context }) => {
+    const { access_token, error } = search;
+    const { queryClient } = context;
+
+    if (error) {
+      toast.error(`Authentication failed: ${error}`);
+      throw redirect({ to: '/login' });
+    }
+
+    if (!access_token) {
+      toast.error('No access token received');
+      throw redirect({ to: '/login' });
+    }
+
+    // Save token
+    localStorage.setItem('accessToken', access_token);
+
+    // Fetch user using the token
+    const user = await authApi.getCurrentUser();
+    queryClient.setQueryData(CURRENT_USER_KEY, user);
+
+    toast.success('Successfully signed in with Google');
+
+    throw redirect({ to: '/dashboard' });
+  },
+
+  component: OAuth2RedirectPage,
+});
+
+function OAuth2RedirectPage() {
+  return <LoadingSpinner />;
+}


### PR DESCRIPTION
This PR introduces Google OAuth integration into our existing auth system.

### Key Updates
- Added `getGoogleAuthUrl()` in `authApi` and `useGoogleLogin` hook in `use-auth` for centralized OAuth URL generation & redirection.
- Updated Login and Register pages to use the new Google login hook.
- Handle oauth callback  at `/oauth2/redirect`
- Update React Query cache with authenticated user

### Notes
Some refinements may be needed as backend OAuth flow evolves including major security ones.
> For example: Currently reading `access_token` from URL query params. 