### PR TITLE
Implement secure token-based forget/reset password feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage/
 *.njsproj
 *.sln
 *.sw?
+
+# Temporary files
+.tanstack/tmp

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -31,6 +31,17 @@ export const authApi = {
     return response.data;
   },
 
+  forgotPassword: async (email: string): Promise<void> => {
+    await apiClient.post('/auth/forgot-password', { email });
+  },
+
+  resetPassword: async (data: {
+    token: string;
+    newPassword: string;
+  }): Promise<void> => {
+    await apiClient.post('/auth/reset-password', data);
+  },
+
   getGoogleAuthUrl: (): string => {
     const baseUrl =
       import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/';

--- a/src/hooks/use-password.ts
+++ b/src/hooks/use-password.ts
@@ -1,0 +1,42 @@
+import { useMutation } from '@tanstack/react-query';
+import { authApi } from '@/api/auth';
+import { toast } from 'sonner';
+
+export function useForgotPassword() {
+  return useMutation({
+    mutationFn: (email: string) => authApi.forgotPassword(email),
+
+    onSuccess: () => {
+      toast.success(
+        'Check your email for a link to reset your password'
+      );
+    },
+
+    onError: () => {
+      // Always generic (security)
+      toast.success(
+        'Check your email for a link to reset your password'
+      );
+    },
+  });
+}
+
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: (data: {
+      token: string;
+      newPassword: string;
+    }) => authApi.resetPassword(data),
+
+    onSuccess: () => {
+      toast.success('Password updated successfully');
+    },
+
+    onError: () => {
+      toast.error(
+        'Invalid or expired reset link'
+      );
+    },
+  });
+}
+

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as PublicIndexRouteImport } from './routes/_public/index'
 import { Route as Oauth2RedirectRouteImport } from './routes/oauth2/redirect'
 import { Route as PublicDocsRouteImport } from './routes/_public/docs'
 import { Route as ProtectedDashboardRouteImport } from './routes/_protected/dashboard'
+import { Route as AuthResetPasswordRouteImport } from './routes/_auth/reset-password'
 import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as ProtectedOrganizationsIndexRouteImport } from './routes/_protected/organizations/index'
@@ -61,6 +62,11 @@ const ProtectedDashboardRoute = ProtectedDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => ProtectedRouteRoute,
 } as any)
+const AuthResetPasswordRoute = AuthResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
 const AuthRegisterRoute = AuthRegisterRouteImport.update({
   id: '/register',
   path: '/register',
@@ -100,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/$': typeof SplatRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
+  '/reset-password': typeof AuthResetPasswordRoute
   '/dashboard': typeof ProtectedDashboardRoute
   '/docs': typeof PublicDocsRoute
   '/oauth2/redirect': typeof Oauth2RedirectRoute
@@ -113,6 +120,7 @@ export interface FileRoutesByTo {
   '/$': typeof SplatRoute
   '/login': typeof AuthLoginRoute
   '/register': typeof AuthRegisterRoute
+  '/reset-password': typeof AuthResetPasswordRoute
   '/dashboard': typeof ProtectedDashboardRoute
   '/docs': typeof PublicDocsRoute
   '/oauth2/redirect': typeof Oauth2RedirectRoute
@@ -130,6 +138,7 @@ export interface FileRoutesById {
   '/$': typeof SplatRoute
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/register': typeof AuthRegisterRoute
+  '/_auth/reset-password': typeof AuthResetPasswordRoute
   '/_protected/dashboard': typeof ProtectedDashboardRoute
   '/_public/docs': typeof PublicDocsRoute
   '/oauth2/redirect': typeof Oauth2RedirectRoute
@@ -145,6 +154,7 @@ export interface FileRouteTypes {
     | '/$'
     | '/login'
     | '/register'
+    | '/reset-password'
     | '/dashboard'
     | '/docs'
     | '/oauth2/redirect'
@@ -158,6 +168,7 @@ export interface FileRouteTypes {
     | '/$'
     | '/login'
     | '/register'
+    | '/reset-password'
     | '/dashboard'
     | '/docs'
     | '/oauth2/redirect'
@@ -174,6 +185,7 @@ export interface FileRouteTypes {
     | '/$'
     | '/_auth/login'
     | '/_auth/register'
+    | '/_auth/reset-password'
     | '/_protected/dashboard'
     | '/_public/docs'
     | '/oauth2/redirect'
@@ -250,6 +262,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedDashboardRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
+    '/_auth/reset-password': {
+      id: '/_auth/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof AuthResetPasswordRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
     '/_auth/register': {
       id: '/_auth/register'
       path: '/register'
@@ -298,11 +317,13 @@ declare module '@tanstack/react-router' {
 interface AuthRouteRouteChildren {
   AuthLoginRoute: typeof AuthLoginRoute
   AuthRegisterRoute: typeof AuthRegisterRoute
+  AuthResetPasswordRoute: typeof AuthResetPasswordRoute
 }
 
 const AuthRouteRouteChildren: AuthRouteRouteChildren = {
   AuthLoginRoute: AuthLoginRoute,
   AuthRegisterRoute: AuthRegisterRoute,
+  AuthResetPasswordRoute: AuthResetPasswordRoute,
 }
 
 const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(

--- a/src/routes/_auth/login.tsx
+++ b/src/routes/_auth/login.tsx
@@ -132,6 +132,17 @@ function LoginPage() {
                   </FormItem>
                 )}
               />
+
+              {/* TODO: Adjust the gap between forget password link and the input field */}
+              <div className="flex justify-end">
+                <Link
+                  to="/reset-password"
+                  className="text-xs text-primary hover:underline"
+                >
+                  Forgot password?
+                </Link>
+              </div>
+
               <FormField
                 control={form.control}
                 name="password"

--- a/src/routes/_auth/reset-password.tsx
+++ b/src/routes/_auth/reset-password.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import {
+  createFileRoute,
+  Link,
+  useNavigate,
+  useSearch,
+} from '@tanstack/react-router';
+import {
+  useForgotPassword,
+  useResetPassword,
+} from '@/hooks/use-password';
+
+export const Route = createFileRoute('/_auth/reset-password')({
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      token: typeof search.token === 'string' ? search.token : undefined,
+    };
+  },
+  component: ResetPasswordPage,
+});
+
+export default function ResetPasswordPage() {
+  const search = useSearch({ from: '/_auth/reset-password' });
+  const token = search.token ?? null;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-md space-y-6">
+        {!token ? (
+          <ForgotPasswordView />
+        ) : (
+          <ResetPasswordView token={token} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// FORGOT PASSWORD
+function ForgotPasswordView() {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const forgotPassword = useForgotPassword();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    forgotPassword.mutate(email.trim(), {
+      onSettled: () => setSubmitted(true), // success OR error
+    });
+  };
+
+  if (submitted) {
+    return (
+      <div className="space-y-4 text-center">
+        <h1 className="text-xl font-semibold">Reset your password</h1>
+
+        <p className="text-sm text-muted-foreground">
+          Check your email for a link to reset your password.
+          If it doesn’t appear within a few minutes, check your spam folder.
+        </p>
+
+        <Link to="/login" className="text-sm text-primary">
+          Return to sign in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <h1 className="text-xl font-semibold text-center">
+        Reset your password
+      </h1>
+
+      <input
+        type="email"
+        required
+        placeholder="Enter your email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="w-full rounded border px-3 py-2"
+      />
+
+      <button
+        type="submit"
+        disabled={forgotPassword.isPending}
+        className="w-full rounded bg-primary py-2 text-white disabled:opacity-60"
+      >
+        {forgotPassword.isPending ? 'Sending…' : 'Send reset link'}
+      </button>
+
+      <div className="text-center">
+        <Link to="/login" className="text-sm text-primary">
+          Return to sign in
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+// RESET PASSWORD
+function ResetPasswordView({ token }: { token: string }) {
+  const navigate = useNavigate();
+  const resetPassword = useResetPassword();
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const isValidPassword =
+    password.length >= 15 ||
+    (password.length >= 8 &&
+      /[a-z]/.test(password) &&
+      /[0-9]/.test(password));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (!isValidPassword) {
+      setError('Password does not meet requirements');
+      return;
+    }
+
+    setError('');
+
+    resetPassword.mutate(
+      { token, newPassword: password },
+      {
+        onSuccess: () => {
+          navigate({ to: '/login' });
+        },
+      }
+    );
+  };
+
+  if (resetPassword.isError) {
+    return (
+      <div className="space-y-4 text-center">
+        <h1 className="text-xl font-semibold">
+          Reset link invalid or expired
+        </h1>
+
+        <p className="text-sm text-muted-foreground">
+          Please request a new password reset link.
+        </p>
+
+        <Link to="/reset-password" className="text-sm text-primary">
+          Request new reset link
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <h1 className="text-xl font-semibold text-center">
+        Change your password
+      </h1>
+
+      <p className="text-sm text-muted-foreground">
+        Make sure it's at least 15 characters OR at least 8 characters
+        including a number and a lowercase letter.
+      </p>
+
+      <input
+        type="password"
+        placeholder="New password"
+        value={password}
+        onChange={(e) => {
+          setPassword(e.target.value);
+          setError('');
+        }}
+        className="w-full rounded border px-3 py-2"
+      />
+
+      <input
+        type="password"
+        placeholder="Confirm password"
+        value={confirmPassword}
+        onChange={(e) => {
+          setConfirmPassword(e.target.value);
+          setError('');
+        }}
+        className="w-full rounded border px-3 py-2"
+      />
+
+      {error && (
+        <p className="text-sm text-red-500">{error}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={resetPassword.isPending}
+        className="w-full rounded bg-primary py-2 text-white disabled:opacity-60"
+      >
+        {resetPassword.isPending ? 'Updating…' : 'Update password'}
+      </button>
+
+      <div className="text-center">
+        <Link to="/login" className="text-sm text-primary">
+          Return to sign in
+        </Link>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
### Overview
This PR implements the complete token-based forget and reset password feature for Mockify.

### Changes 
- Added "Forgot password?" link to the login page
- Created `authApi.forgotPassword` and `authApi.resetPassword` for API calls
- Implemented `useForgotPassword` and `useResetPassword` hooks using React Query
- Developed a single decent `ResetPasswordPage` that handles: 
  - **Forgot password flow:** user submits email, sees success message
  - **Reset password flow:** user clicks link with token, sets new password
- Added frontend validation for password strength and confirm password

### Security 
- Success message shown regardless of whether email exists (prevents email enumeration)
- Token validation handled gracefully with clear UI
- Inline validation for password requirements before calling API
- Navigates to login page after successful password reset