### PR TITLE
update email verification page to avoid auto-login and redirect to login

### DIFF
--- a/src/routes/_auth/register.tsx
+++ b/src/routes/_auth/register.tsx
@@ -51,8 +51,6 @@ type RegisterForm = z.infer<typeof registerSchema>;
 
 function RegisterPage() {
   const { register } = useAuth();
-  // CHANGED: removed `isAuthenticated`
-  // WHY: registration should NOT auto-redirect based on auth state
 
   const { initiateGoogleLogin } = useGoogleLogin();
   const navigate = useNavigate();
@@ -68,21 +66,17 @@ function RegisterPage() {
     },
   });
 
-  //  REMOVED useEffect that redirected to /dashboard
-  // user is NOT verified yet, should stay public
 
   const onSubmit = async (data: RegisterForm) => {
     setIsLoading(true);
     try {
       await register(data.name, data.email, data.password);
 
-      //  CHANGED: message now informs about email verification
       toast.success(
         'Account created successfully. Please check your email to verify your account.',
       );
-
-      // CHANGED: redirect to login instead of dashboard
-      navigate({ to: '/dashboard' });
+      
+      navigate({ to: '/login' });
     } catch (error) {
       toast.error(handleApiError(error));
     } finally {

--- a/src/routes/_public/verify-email.tsx
+++ b/src/routes/_public/verify-email.tsx
@@ -3,8 +3,6 @@ import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { useQueryClient } from '@tanstack/react-query';
-import { CURRENT_USER_KEY } from '@/hooks/use-auth';
-import { tokenStore } from '@/api/token';
 import { authApi } from '@/api/auth';
 
 export const Route = createFileRoute('/_public/verify-email')({
@@ -35,15 +33,11 @@ function VerifyEmailPage() {
       }
 
       try {
-        const data = await authApi.verifyEmail(token);
-
-        tokenStore.set(data.access_token);
-        queryClient.setQueryData(CURRENT_USER_KEY, data.user);
+         await authApi.verifyEmail(token);
 
         setStatus('success');
-
         setTimeout(() => {
-          navigate({ to: '/dashboard' });
+          navigate({ to: '/login' });
         }, 800);
       } catch (err) {
         console.error('Verification failed:', err);


### PR DESCRIPTION
#### This PR updates the frontend authentication flow to properly separate email verification from user authentication.

#### Previously, the email verification page attempted to store access tokens and treat verification as an authenticated state. This behavior has been removed to align with the updated backend logic and improve security.

#### After this change, users are explicitly redirected to the login page after successful email verification and must log in to receive authentication tokens.
## What’s Changed

- Removed token storage and user caching from the email verification page
- Updated email verification flow to only:
- Validate the verification token
- Show success/error feedback
- Redirect users to the login page
- Ensured authentication state is established only during login

## Why This Change

- Prevents implicit or automatic login via email verification links
- Avoids potential token leakage through URLs or email clients
- Enforces a clear and secure authentication flow
- Keeps frontend behavior consistent with backend design