### PR TITLE
Integrate Dashboard Stats API

### DIFF
--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -1,0 +1,29 @@
+import { apiClient } from "./client";
+import type {UserStats, OrganizationStats, ProjectStats, SchemaStats, RecordHealthStats} from "./types";
+
+export const dashboardApi = {
+    getUserStats: async (): Promise<UserStats> => {
+        const response = await apiClient.get<UserStats>('/dashboard/user');
+        return response.data;
+    },
+
+    getOrganizationStats: async (orgId: string): Promise<OrganizationStats> => {
+        const response = await apiClient.get<OrganizationStats>(`/dashboard/organization/${orgId}`);
+        return response.data;
+    },
+
+    getProjectStats: async (projectId: string): Promise<ProjectStats> => {
+        const response = await apiClient.get<ProjectStats>(`/dashboard/project/${projectId}`);
+        return response.data;
+    },
+
+    getSchemaStats: async (schemaId: string): Promise<SchemaStats> => {
+        const response = await apiClient.get<SchemaStats>(`/dashboard/schema/${schemaId}`);
+        return response.data;
+    },
+
+    getRecordStats: async (): Promise<RecordHealthStats> => {
+        const response = await apiClient.get<RecordHealthStats>(`/dashboard/record/health`);
+        return response.data;
+    }
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -160,3 +160,37 @@ export interface ApiError {
   path: string;
   validationErrors?: Record<string, string[]>;
 }
+
+export interface UserStats {
+  organizationCount: number;
+  projectCount: number;
+  schemaCount: number;
+  recordCount: number;
+}
+
+export interface OrganizationStats {
+  projectCount: number;
+  schemaCount: number;
+  recordCount: number;
+}
+
+export interface ProjectStats {
+  schemaCount: number;
+  recordCount: number;
+  activeRecords: number;
+  expiredRecords: number;
+}
+
+export interface SchemaStats {
+  recordCount: number;
+  activeRecords: number;
+  expiredRecords: number;
+  expiringSoonRecords: number;
+}
+
+export interface RecordHealthStats {
+  totalRecords: number;
+  totalActiveRecords: number;
+  totalExpiredRecords: number;
+  totalExpiringSoonRecords: number;
+}

--- a/src/hooks/use-DashboardStats.ts
+++ b/src/hooks/use-DashboardStats.ts
@@ -1,0 +1,42 @@
+import { dashboardApi } from "@/api/dashboard"
+import { useQuery } from "@tanstack/react-query"
+
+export const useUserStats = () => {
+    return useQuery({
+        queryKey: ['dashboard', 'user'],
+        queryFn: dashboardApi.getUserStats,
+        refetchInterval: 60_000, // Refresh every 60s
+    });
+};
+
+export const useOrganizationStats = (orgId: string) => {
+    return useQuery({
+        queryKey: ['dashboard', 'organization', orgId],
+        queryFn: () => dashboardApi.getOrganizationStats(orgId),
+        enabled: !!orgId,
+    });
+};
+
+export const useProjectStats = (projectId: string) => {
+    return useQuery({
+        queryKey: ['dashboard', 'project', projectId],
+        queryFn: () => dashboardApi.getProjectStats(projectId),
+        enabled: !!projectId,
+    });
+};
+
+export const useSchemaStats = (schemaId: string) => {
+    return useQuery({
+        queryKey: ['dashboard', 'schema', schemaId],
+        queryFn: () => dashboardApi.getSchemaStats(schemaId),
+        enabled: !!schemaId,
+    });
+}
+
+export const useRecordHealthStats = () => {
+    return useQuery({
+        queryKey: ['dashboard', 'record', 'health'],
+        queryFn: dashboardApi.getRecordStats,
+        refetchInterval: 60_000, // Refresh every 60s
+    });
+}

--- a/src/hooks/use-organizations.ts
+++ b/src/hooks/use-organizations.ts
@@ -25,6 +25,7 @@ export function useCreateOrganization() {
     mutationFn: (data: OrganizationInput) => organizationsApi.create(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['organizations'] });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
     },
     onError: (error: any) => {
       toast.error(
@@ -43,6 +44,7 @@ export function useUpdateOrganization() {
     onSuccess: (_, { slug }) => {
       queryClient.invalidateQueries({ queryKey: ['organizations'] });
       queryClient.invalidateQueries({ queryKey: ['organizations', slug] });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
     },
     onError: (error: any) => {
       toast.error(
@@ -59,6 +61,7 @@ export function useDeleteOrganization() {
     mutationFn: (slug: string) => organizationsApi.delete(slug),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['organizations'] });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
     },
     onError: (error: any) => {
       toast.error(

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -33,6 +33,7 @@ export function useCreateProject(orgSlug: string) {
       queryClient.invalidateQueries({
         queryKey: ['organizations', orgSlug],
       });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
     },
   });
 }
@@ -56,6 +57,7 @@ export function useUpdateProject(orgSlug: string) {
       queryClient.invalidateQueries({
         queryKey: ['projects', orgSlug, projectSlug],
       });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
     },
   });
 }
@@ -74,6 +76,7 @@ export function useDeleteProject(orgSlug: string) {
       queryClient.invalidateQueries({
         queryKey: ['organizations', orgSlug],
       });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
     },
   });
 }

--- a/src/hooks/use-records.ts
+++ b/src/hooks/use-records.ts
@@ -46,6 +46,12 @@ export function useCreateRecord(
       queryClient.invalidateQueries({
         queryKey: ['schemas', orgSlug, projectSlug, schemaSlug],
       });
+            queryClient.invalidateQueries({
+        queryKey: ['projects', orgSlug, projectSlug],
+      });
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'project']});
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']});  
       toast.success('Record created successfully');
     },
 
@@ -69,10 +75,16 @@ export function useUpdateRecord(
       recordsApi.update(orgSlug, projectSlug, schemaSlug, recordId, data),
 
     onSuccess: (result) => {
-      queryClient.invalidateQueries({ queryKey: ['records', result.id] });
-      queryClient.invalidateQueries({
+        queryClient.invalidateQueries({ queryKey: ['records', result.id] });
+        queryClient.invalidateQueries({
         queryKey: ['schemas', result.schemaId, 'records'],
       });
+        queryClient.invalidateQueries({
+        queryKey: ['projects', orgSlug, projectSlug],
+      });
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'project']});
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']}); 
       toast.success('Record updated successfully');
     },
     onError: (error: any) => {
@@ -96,6 +108,12 @@ export function useDeleteRecord(
       queryClient.invalidateQueries({
         queryKey: ['schemas', orgSlug, projectSlug, schemaSlug],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['projects', orgSlug, projectSlug],
+      });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']}); 
       toast.success('Record deleted successfully');
     },
 

--- a/src/hooks/use-schemas.ts
+++ b/src/hooks/use-schemas.ts
@@ -47,6 +47,9 @@ export function useCreateSchema(
       queryClient.invalidateQueries({
         queryKey: ['projects', orgSlug, projectSlug],
       });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']}); 
     },
   });
 }
@@ -79,6 +82,8 @@ export function useUpdateSchema(
           schemaSlug,
         ],
       });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
     },
   });
 }
@@ -97,6 +102,8 @@ export function useDeleteSchema(
       queryClient.invalidateQueries({
         queryKey: ['projects', orgSlug, projectSlug],
       });
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+      queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
     },
 
     onError: (error: any) => {

--- a/src/routes/_protected/_projects/$orgSlug/$projectSlug.tsx
+++ b/src/routes/_protected/_projects/$orgSlug/$projectSlug.tsx
@@ -33,6 +33,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatRelativeTime } from '@/lib/utils';
+import { useProjectStats } from '@/hooks/use-DashboardStats';
 
 export const Route = createFileRoute('/_protected/_projects/$orgSlug/$projectSlug')({
   component: ProjectDetail,
@@ -41,6 +42,8 @@ export const Route = createFileRoute('/_protected/_projects/$orgSlug/$projectSlu
 function ProjectDetail() {
   const { orgSlug, projectSlug } = Route.useParams();
   const { data: project, isLoading } = useProject(orgSlug, projectSlug);
+  const { data: projectStats, isLoading: isProjectStatsLoading } = useProjectStats(project?.id);
+  console.log("Project Stats: ", projectStats);
 
   const createSchemaMutation = useCreateSchema(orgSlug, projectSlug);
   const deleteSchemaMutation = useDeleteSchema(orgSlug, projectSlug);
@@ -204,7 +207,7 @@ function ProjectDetail() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {project.stats.totalSchemas}
+              {isProjectStatsLoading ? '...' : projectStats?.schemaCount}
             </div>
           </CardContent>
         </Card>
@@ -214,7 +217,7 @@ function ProjectDetail() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {project.stats.totalRecords}
+              {isProjectStatsLoading ? '...' : projectStats?.recordCount}
             </div>
           </CardContent>
         </Card>
@@ -226,7 +229,7 @@ function ProjectDetail() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600">
-              {project.stats.activeRecords}
+              {isProjectStatsLoading ? '...' : projectStats?.activeRecords}
             </div>
           </CardContent>
         </Card>

--- a/src/routes/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug.tsx
+++ b/src/routes/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { useSchemaStats } from '@/hooks/use-DashboardStats';
 
 export const Route = createFileRoute('/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug')({
   component: SchemaDetail,
@@ -32,6 +33,7 @@ export const Route = createFileRoute('/_protected/_schemas/$orgSlug/$projectSlug
 function SchemaDetail() {
   const { orgSlug, projectSlug, schemaSlug } = Route.useParams();
   const { data: schema, isLoading } = useSchema(orgSlug, projectSlug, schemaSlug);
+  const { data: schemaStats, isLoading: isSchemaStatsLoading } = useSchemaStats(schema?.id);
   const createRecordMutation = useCreateRecord(orgSlug, projectSlug, schemaSlug);
   const deleteRecordMutation = useDeleteRecord(orgSlug, projectSlug, schemaSlug);
 
@@ -144,7 +146,7 @@ function SchemaDetail() {
                     Cancel
                   </Button>
                   <Button
-                    onClick={() => handleCreateRecord(schemaSlug)}
+                    onClick={() => handleCreateRecord()}
                     disabled={createRecordMutation.isPending}
                   >
                     {createRecordMutation.isPending ? 'Creating...' : 'Create'}
@@ -157,34 +159,44 @@ function SchemaDetail() {
       </div>
 
       {/* Stats */}
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Total Records</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {schema.stats.totalRecords}
+              {isSchemaStatsLoading ? '...' : schemaStats?.recordCount}
             </div>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">Active</CardTitle>
+            <CardTitle className="text-sm font-medium">Active Records</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600">
-              {schema.stats.activeRecords}
+              {isSchemaStatsLoading ? '...' : schemaStats?.activeRecords}
             </div>
           </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">Expired</CardTitle>
+            <CardTitle className="text-sm font-medium">Expiring Soon</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-yellow-600">
+              {isSchemaStatsLoading ? '...' : schemaStats?.expiringSoonRecords}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Expired Records</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-red-600">
-              {schema.stats.expiredRecords}
+              {isSchemaStatsLoading ? '...' : schemaStats?.expiredRecords}
             </div>
           </CardContent>
         </Card>

--- a/src/routes/_protected/dashboard.tsx
+++ b/src/routes/_protected/dashboard.tsx
@@ -17,6 +17,7 @@ import {
 import { useAuth } from '@/hooks/useAuth';
 import { useOrganizations } from '@/hooks/use-organizations';
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
+import { useUserStats } from '@/hooks/use-DashboardStats';
 
 export const Route = createFileRoute('/_protected/dashboard')({
   component: DashboardPage,
@@ -25,9 +26,12 @@ export const Route = createFileRoute('/_protected/dashboard')({
 export function DashboardPage() {
   const { user } = useAuth();
   const { data: organizations, isLoading } = useOrganizations();
+  const { data: userStats, isLoading: isUserStatsLoading, error } = useUserStats();
+  console.log("User stats: ", userStats);
+  console.log("Error: ", error);
   console.log(organizations);
 
-  if (isLoading) {
+  if (isLoading || isUserStatsLoading) {
     return <LoadingSpinner fullScreen />;
   }
 
@@ -51,7 +55,7 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {isLoading ? '...' : organizations?.length}
+              {isUserStatsLoading ? '...' : userStats?.organizationCount}
             </div>
             <p className="text-xs text-muted-foreground">Total organizations</p>
           </CardContent>
@@ -64,12 +68,7 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {isLoading
-                ? '...'
-                : organizations?.reduce(
-                    (acc, org) => acc + org.projectCount,
-                    0,
-                  )}
+              {isUserStatsLoading ? '...' : userStats?.projectCount}
             </div>
             <p className="text-xs text-muted-foreground">
               Across all organizations
@@ -83,7 +82,9 @@ export function DashboardPage() {
             <FileCode className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
+            <div className="text-2xl font-bold">
+              {isUserStatsLoading ? '...' : userStats?.schemaCount}
+            </div>
             <p className="text-xs text-muted-foreground">Mock data schemas</p>
           </CardContent>
         </Card>
@@ -94,7 +95,9 @@ export function DashboardPage() {
             <Database className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
+            <div className="text-2xl font-bold">
+              {isUserStatsLoading ? '...' : userStats?.recordCount}
+            </div>
             <p className="text-xs text-muted-foreground">
               Mock records created
             </p>


### PR DESCRIPTION
This PR integrates backend dashboard statistics APIs into the frontend.

Changes included:
- Added dashboard API functions for user, org, project, schema and record heath  stats
- Integrated React Query hooks for fetching stats
- Displayed stats on Dashboard, Project and Schema pages
- Fixed cache invalidation to refresh stats after create/delete actions
- Ensured record and schema counts stay in sync across pages

This improves dashboard accuracy and keeps stats updated without page refresh.
