### PR TITLE
API Key Management — frontend for backend PR #65

### DIFF
--- a/src/api/api-key.ts
+++ b/src/api/api-key.ts
@@ -1,0 +1,97 @@
+import { apiClient } from './client';
+import type {
+  ApiKeyResponse,
+  CreateApiKeyRequest,
+  CreateApiKeyResult,
+  UpdateApiKeyRequest,
+} from './types';
+
+/**
+ * All endpoints live under /api/{org}/api-keys
+ * ALL calls require JWT authentication — API keys cannot manage API keys.
+ */
+export const apiKeysApi = {
+  /**
+   * GET /api/{org}/api-keys
+   * Returns all API keys for the organisation (active + revoked).
+   */
+  list: async (orgSlug: string): Promise<ApiKeyResponse[]> => {
+    const res = await apiClient.get<ApiKeyResponse[]>(`/${orgSlug}/api-keys`);
+    return res.data;
+  },
+
+  /**
+   * GET /api/{org}/api-keys/{keyId}
+   */
+  getById: async (orgSlug: string, keyId: string): Promise<ApiKeyResponse> => {
+    const res = await apiClient.get<ApiKeyResponse>(
+      `/${orgSlug}/api-keys/${keyId}`,
+    );
+    return res.data;
+  },
+
+  /**
+   * POST /api/{org}/api-keys
+   * Returns CreateApiKeyResult — plainTextKey is shown ONCE, then gone.
+   */
+  create: async (
+    orgSlug: string,
+    data: CreateApiKeyRequest,
+  ): Promise<CreateApiKeyResult> => {
+    const res = await apiClient.post<CreateApiKeyResult>(
+      `/${orgSlug}/api-keys`,
+      data,
+    );
+    return res.data;
+  },
+
+  /**
+   * PUT /api/{org}/api-keys/{keyId}
+   * Supports partial updates: name, description, rateLimitPerMinute.
+   */
+  update: async (
+    orgSlug: string,
+    keyId: string,
+    data: UpdateApiKeyRequest,
+  ): Promise<ApiKeyResponse> => {
+    const res = await apiClient.put<ApiKeyResponse>(
+      `/${orgSlug}/api-keys/${keyId}`,
+      data,
+    );
+    return res.data;
+  },
+
+  /**
+   * POST /api/{org}/api-keys/{keyId}/revoke
+   * Marks key as inactive. Key remains in the list with active: false.
+   */
+  revoke: async (orgSlug: string, keyId: string): Promise<ApiKeyResponse> => {
+    const res = await apiClient.post<ApiKeyResponse>(
+      `/${orgSlug}/api-keys/${keyId}/revoke`,
+    );
+    return res.data;
+  },
+
+  /**
+   * DELETE /api/{org}/api-keys/{keyId}
+   * Permanently deletes the key record.
+   */
+  delete: async (orgSlug: string, keyId: string): Promise<void> => {
+    await apiClient.delete(`/${orgSlug}/api-keys/${keyId}`);
+  },
+
+  /**
+   * POST /api/{org}/api-keys/{keyId}/rotate
+   * Generates a new secret, invalidates the old one.
+   * Returns CreateApiKeyResult — new plainTextKey is shown ONCE.
+   */
+  rotate: async (
+    orgSlug: string,
+    keyId: string,
+  ): Promise<CreateApiKeyResult> => {
+    const res = await apiClient.post<CreateApiKeyResult>(
+      `/${orgSlug}/api-keys/${keyId}/rotate`,
+    );
+    return res.data;
+  },
+};

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,11 +1,12 @@
 import { apiClient as api } from '@/api/client';
-import type { Project, ProjectDetail } from '@/api/types';
+import type { PaginatedResponse, Project, ProjectDetail } from '@/api/types';
 
 export const projectsApi = {
-  getAllByOrg: async (orgSlug: string): Promise<Project[]> => {
-    const response = await api.get(`/${orgSlug}/projects`);
-    return response.data;
-  },
+ getAllByOrg: async (orgSlug: string): Promise<Project[]> => {
+  const response = await api.get<PaginatedResponse<Project>>(`/${orgSlug}/projects`);
+  const { data: projects } = response.data;
+  return projects;
+ },
 
   getBySlug: async (
     orgSlug: string, projectSlug: string

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -211,7 +211,7 @@ export interface ApiKeyResponse {
   rateLimitPerMinute: number;
 
   /** false after revocation */
-  isActive: boolean;
+  active: boolean;
 
   /** ISO-8601 datetime; absent = never expires */
   expiresAt?: string;
@@ -262,7 +262,7 @@ export interface UpdateApiKeyRequest {
   rateLimitPerMinute?: number;
 
   /** Activate/deactivate key */
-  isActive?: boolean;
+  active?: boolean;
 
   /** Update expiry */
   expiresAt?: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -49,7 +49,6 @@ export interface OrganizationDetail {
   projects: ProjectSummary[];
 }
 
-
 export interface ProjectSummary {
   id: string;
   name: string;
@@ -82,7 +81,6 @@ export interface ProjectDetail {
   schemas: MockSchemaSummary[];
   stats: ProjectStats;
 }
-
 
 export interface ProjectStats {
   totalSchemas: number;
@@ -159,4 +157,113 @@ export interface ApiError {
   timestamp: string;
   path: string;
   validationErrors?: Record<string, string[]>;
+}
+
+// API KEY TYPES
+
+/**
+ * Hierarchical permission levels.
+ * Server enforces: ADMIN ≥ DELETE ≥ WRITE ≥ READ
+ */
+export type ApiPermission = 'READ' | 'WRITE' | 'DELETE' | 'ADMIN';
+
+/** Resource types that can be targeted by a permission grant */
+export type ApiResourceType = 'ORGANIZATION' | 'PROJECT' | 'SCHEMA' | 'RECORD';
+
+/**
+ * Permission entry
+ */
+export interface ApiKeyPermissionEntry {
+  id: string;
+
+  resourceType: ApiResourceType;
+  resourceName?: string;
+
+  permission: ApiPermission;
+
+  /** Undefined/null = wildcard (all resources of this type) */
+  resourceId?: string;
+}
+
+/**
+ * Represents a persisted API key
+ */
+export interface ApiKeyResponse {
+  id: string;
+  name: string;
+  description?: string;
+
+  /** Visible prefix shown in the UI */
+  keyPrefix: string;
+
+  organizationId: string;
+  organizationName: string;
+
+  /** Set = project-scoped; null = org-wide */
+  projectId?: string;
+  projectName?: string;
+
+  createdBy: string;
+  createdByName: string;
+
+  permissions: ApiKeyPermissionEntry[];
+
+  rateLimitPerMinute: number;
+
+  /** false after revocation */
+  isActive: boolean;
+
+  /** ISO-8601 datetime; absent = never expires */
+  expiresAt?: string;
+
+  /** ISO-8601 datetime */
+  lastUsedAt?: string;
+
+  createdAt: string;
+  updatedAt?: string;
+}
+
+/**
+ * Returned only by the create and rotate endpoints.
+ * `apiKey` is the ONLY time the full secret is exposed.
+ */
+export interface CreateApiKeyResult {
+  apiKey: string;
+  keyInfo: ApiKeyResponse;
+
+  /** Informational message from backend */
+  securityNotice?: string;
+}
+
+export interface CreateApiKeyRequest {
+  name: string;
+  description?: string;
+
+  /** UUID of the project to scope this key to (omit for org-wide) */
+  projectId?: string;
+
+  /** ISO-8601 future datetime */
+  expiresAt?: string;
+
+  /** Default: 1000 */
+  rateLimitPerMinute?: number;
+
+  permissions: {
+    permission: ApiPermission;
+    resourceType: ApiResourceType;
+    resourceId?: string;
+  }[];
+}
+
+export interface UpdateApiKeyRequest {
+  name?: string;
+  description?: string;
+
+  rateLimitPerMinute?: number;
+
+  /** Activate/deactivate key */
+  isActive?: boolean;
+
+  /** Update expiry */
+  expiresAt?: string;
 }

--- a/src/components/api-key/ApiKeyTable.tsx
+++ b/src/components/api-key/ApiKeyTable.tsx
@@ -1,0 +1,314 @@
+import { useState } from 'react';
+import {
+  RefreshCw,
+  Ban,
+  Trash2,
+  MoreHorizontal,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Zap,
+  Globe,
+  FolderKanban,
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PermissionBadgeList } from './PermissionBadge';
+import { RotateKeyDialog } from './RotateKeyDialog';
+import { RevokeKeyDialog } from './RevokeKeyDialog';
+import { DeleteKeyDialog } from './DeleteKeyDialog';
+import { formatRelativeTime } from '@/lib/utils';
+import type { ApiKeyResponse } from '@/api/types';
+
+// -------- Status badge --------
+
+function StatusBadge({
+  active,
+  expired,
+}: {
+  active: boolean;
+  expired: boolean;
+}) {
+  if (expired) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-orange-300 bg-orange-100 px-2 py-0.5 text-[11px] font-medium text-orange-800 dark:border-orange-700 dark:bg-orange-950 dark:text-orange-300">
+        <Clock className="h-2.5 w-2.5" />
+        Expired
+      </span>
+    );
+  }
+  if (!active) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-red-300 bg-red-100 px-2 py-0.5 text-[11px] font-medium text-red-800 dark:border-red-700 dark:bg-red-950 dark:text-red-300">
+        <XCircle className="h-2.5 w-2.5" />
+        Revoked
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-green-300 bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-800 dark:border-green-700 dark:bg-green-950 dark:text-green-300">
+      <CheckCircle2 className="h-2.5 w-2.5" />
+      Active
+    </span>
+  );
+}
+
+// -------- Scope badge --------
+
+interface ScopeBadgeProps {
+  projectId?: string;
+  /**
+   * Pass the projects list from the parent (already fetched) to resolve
+   * the project name from its ID without an extra network call.
+   */
+  projectName?: string;
+}
+
+function ScopeBadge({ projectId, projectName }: ScopeBadgeProps) {
+  if (!projectId) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+        <Globe className="h-2.5 w-2.5" />
+        Org-wide
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded border border-blue-300 bg-blue-100 px-1.5 py-0.5 text-[11px] font-medium text-blue-800 max-w-[120px] dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
+      title={`Project ID: ${projectId}`}
+    >
+      <FolderKanban className="h-2.5 w-2.5 shrink-0" />
+      <span className="truncate">{projectName ?? 'Project-scoped'}</span>
+    </span>
+  );
+}
+
+// -------- Row actions --------
+
+type ModalType = 'rotate' | 'revoke' | 'delete' | null;
+
+interface RowActionsProps {
+  orgSlug: string;
+  apiKey: ApiKeyResponse;
+  isExpired: boolean;
+}
+
+function RowActions({ orgSlug, apiKey, isExpired }: RowActionsProps) {
+  const [modal, setModal] = useState<ModalType>(null);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <MoreHorizontal className="h-4 w-4" />
+            <span className="sr-only">Key actions</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          {apiKey.isActive && !isExpired && (
+            <DropdownMenuItem onClick={() => setModal('rotate')}>
+              <RefreshCw className="mr-2 h-3.5 w-3.5" />
+              Rotate key
+            </DropdownMenuItem>
+          )}
+          {apiKey.isActive && (
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => setModal('revoke')}
+            >
+              <Ban className="mr-2 h-3.5 w-3.5" />
+              Revoke key
+            </DropdownMenuItem>
+          )}
+          {apiKey.isActive && <DropdownMenuSeparator />}
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => setModal('delete')}
+          >
+            <Trash2 className="mr-2 h-3.5 w-3.5" />
+            Delete permanently
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {modal === 'rotate' && (
+        <RotateKeyDialog
+          orgSlug={orgSlug}
+          apiKey={apiKey}
+          open
+          onClose={() => setModal(null)}
+        />
+      )}
+      {modal === 'revoke' && (
+        <RevokeKeyDialog
+          orgSlug={orgSlug}
+          apiKey={apiKey}
+          open
+          onClose={() => setModal(null)}
+        />
+      )}
+      {modal === 'delete' && (
+        <DeleteKeyDialog
+          orgSlug={orgSlug}
+          apiKey={apiKey}
+          open
+          onClose={() => setModal(null)}
+        />
+      )}
+    </>
+  );
+}
+
+// -------- Skeleton --------
+
+export function ApiKeyTableSkeleton() {
+  return (
+    <div className="rounded-lg border divide-y overflow-hidden">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex items-center gap-4 p-4">
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-56" />
+          </div>
+          <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-8 w-8" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// -------- Main table --------
+
+interface ApiKeyTableProps {
+  orgSlug: string;
+  keys: ApiKeyResponse[];
+  /**
+   * Map of projectId → projectName, built from the org's project list.
+   * Used to resolve human-readable names for project-scoped keys.
+   */
+  projectNames?: Record<string, string>;
+}
+
+export function ApiKeyTable({
+  orgSlug,
+  keys,
+  projectNames = {},
+}: ApiKeyTableProps) {
+  if (keys.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border overflow-hidden divide-y">
+      {/* Header row */}
+      <div className="hidden md:grid md:grid-cols-[2fr_1.2fr_1.8fr_1.2fr_1fr_1fr_auto] items-center gap-3 bg-muted/40 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        <span>Name / Key</span>
+        <span>Scope</span>
+        <span>Permissions</span>
+        <span>Usage</span>
+        <span>Rate limit</span>
+        <span>Status</span>
+        <span />
+      </div>
+
+      {keys.map((key) => {
+        const isExpired =
+          !!key.expiresAt && new Date(key.expiresAt) < new Date();
+        const projectName = key.projectId
+          ? projectNames[key.projectId]
+          : undefined;
+        // Normalise stats — backend may omit the field entirely on newly-created
+        // keys, or return it with null inner fields. Guard both cases.
+        const stats = {
+          lastUsedAt: key?.lastUsedAt ?? undefined,
+        };
+
+        return (
+          <div
+            key={key.id}
+            className="grid grid-cols-1 md:grid-cols-[2fr_1.2fr_1.8fr_1.2fr_1fr_1fr_auto] items-center gap-3 px-4 py-3.5 hover:bg-muted/20 transition-colors"
+          >
+            {/* Name + masked key */}
+            <div className="min-w-0 space-y-0.5">
+              <p className="text-sm font-medium leading-none truncate">
+                {key.name}
+              </p>
+              <code className="font-mono text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                {key.keyPrefix}
+              </code>
+              {key.description && (
+                <p className="text-xs text-muted-foreground truncate mt-0.5">
+                  {key.description}
+                </p>
+              )}
+            </div>
+
+            {/* Scope */}
+            <div>
+              <ScopeBadge projectId={key.projectId} projectName={projectName} />
+            </div>
+
+            {/* Permissions */}
+            <div>
+              <PermissionBadgeList
+                permissions={key.permissions ?? []}
+                maxVisible={2}
+              />
+            </div>
+
+            {/* Usage */}
+            <div className="space-y-0.5">
+              {stats.lastUsedAt ? (
+                <p className="text-xs text-muted-foreground">
+                  Last {formatRelativeTime(stats.lastUsedAt)}
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground italic">
+                  Never used
+                </p>
+              )}
+              {key.expiresAt && (
+                <p
+                  className={`text-xs ${isExpired ? 'text-orange-600 dark:text-orange-400' : 'text-muted-foreground'}`}
+                >
+                  {isExpired ? 'Expired ' : 'Expires '}
+                  {formatRelativeTime(key.expiresAt)}
+                </p>
+              )}
+            </div>
+
+            {/* Rate limit */}
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Zap className="h-3 w-3 shrink-0" />
+              <span>{key.rateLimitPerMinute.toLocaleString()}/min</span>
+            </div>
+
+            {/* Status */}
+            <div>
+              <StatusBadge active={key.isActive} expired={isExpired} />
+            </div>
+
+            {/* Actions */}
+            <div className="flex justify-end">
+              <RowActions
+                orgSlug={orgSlug}
+                apiKey={key}
+                isExpired={isExpired}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/api-key/ApiKeyTable.tsx
+++ b/src/components/api-key/ApiKeyTable.tsx
@@ -114,13 +114,13 @@ function RowActions({ orgSlug, apiKey, isExpired }: RowActionsProps) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          {apiKey.isActive && !isExpired && (
+          {apiKey.active && !isExpired && (
             <DropdownMenuItem onClick={() => setModal('rotate')}>
               <RefreshCw className="mr-2 h-3.5 w-3.5" />
               Rotate key
             </DropdownMenuItem>
           )}
-          {apiKey.isActive && (
+          {apiKey.active && (
             <DropdownMenuItem
               className="text-destructive focus:text-destructive"
               onClick={() => setModal('revoke')}
@@ -129,7 +129,7 @@ function RowActions({ orgSlug, apiKey, isExpired }: RowActionsProps) {
               Revoke key
             </DropdownMenuItem>
           )}
-          {apiKey.isActive && <DropdownMenuSeparator />}
+          {apiKey.active && <DropdownMenuSeparator />}
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={() => setModal('delete')}
@@ -295,7 +295,7 @@ export function ApiKeyTable({
 
             {/* Status */}
             <div>
-              <StatusBadge active={key.isActive} expired={isExpired} />
+              <StatusBadge active={key.active} expired={isExpired} />
             </div>
 
             {/* Actions */}

--- a/src/components/api-key/CreateApiKeyDialog.tsx
+++ b/src/components/api-key/CreateApiKeyDialog.tsx
@@ -1,0 +1,594 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { Plus, Trash2, Key, Globe, FolderKanban } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { useCreateApiKey } from '@/hooks/use-api-key';
+import { useProjects } from '@/hooks/use-projects';
+import { KeyReveal } from './KeyReveal';
+import type {
+  ApiPermission,
+  ApiResourceType,
+  CreateApiKeyResult,
+} from '@/api/types';
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+const createKeySchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  description: z.string().max(255).optional(),
+  rateLimitPerMinute: z
+    .number()
+    .int()
+    .min(1, 'Min 1')
+    .max(100_000, 'Max 100 000'),
+  expiresAt: z.string().optional(),
+});
+
+type CreateKeyForm = z.infer<typeof createKeySchema>;
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RESOURCE_TYPES: ApiResourceType[] = [
+  'ORGANIZATION',
+  'PROJECT',
+  'SCHEMA',
+  'RECORD',
+];
+const PERMISSIONS: ApiPermission[] = ['READ', 'WRITE', 'DELETE', 'ADMIN'];
+
+const PERMISSION_HINT: Record<ApiPermission, string> = {
+  READ: 'View only',
+  WRITE: 'Create & update',
+  DELETE: 'Remove resources',
+  ADMIN: 'Full control',
+};
+
+// ─── Permission row state ─────────────────────────────────────────────────────
+
+interface PermRow {
+  id: number;
+  resourceType: ApiResourceType;
+  permission: ApiPermission;
+  resourceId: string;
+}
+
+let _nextId = 1;
+const freshRow = (): PermRow => ({
+  id: _nextId++,
+  resourceType: 'ORGANIZATION',
+  permission: 'READ',
+  resourceId: '',
+});
+
+// ─── Scope selector sub-component ────────────────────────────────────────────
+
+interface ScopeSelectorProps {
+  orgSlug: string;
+  scope: 'org' | 'project';
+  selectedProjectId: string;
+  onScopeChange: (s: 'org' | 'project') => void;
+  onProjectChange: (id: string) => void;
+}
+
+function ScopeSelector({
+  orgSlug,
+  scope,
+  selectedProjectId,
+  onScopeChange,
+  onProjectChange,
+}: ScopeSelectorProps) {
+  const { data: projects = [], isLoading } = useProjects(orgSlug);
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Scope</p>
+      <p className="text-xs text-muted-foreground -mt-1">
+        Org-wide keys can access all projects. Project-scoped keys are locked to
+        one project.
+      </p>
+
+      <div className="grid grid-cols-2 gap-2 mt-2">
+        {/* Org-wide tile */}
+        <button
+          type="button"
+          onClick={() => onScopeChange('org')}
+          className={cn(
+            'flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors',
+            scope === 'org'
+              ? 'border-blue-400 bg-blue-100 ring-1 ring-blue-300 dark:border-blue-600 dark:bg-blue-950/60 dark:ring-blue-700'
+              : 'border-border hover:bg-muted/40',
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Globe
+              className={cn(
+                'h-3.5 w-3.5 shrink-0',
+                scope === 'org'
+                  ? 'text-blue-700 dark:text-blue-400'
+                  : 'text-muted-foreground',
+              )}
+            />
+            <span className="text-sm font-medium">Organization-wide</span>
+          </div>
+          <span className="text-xs text-muted-foreground leading-snug">
+            Accesses all projects in{' '}
+            <span className="font-medium text-foreground">{orgSlug}</span>
+          </span>
+        </button>
+
+        {/* Project-scoped tile */}
+        <button
+          type="button"
+          onClick={() => onScopeChange('project')}
+          className={cn(
+            'flex flex-col items-start gap-1.5 rounded-lg border p-3 text-left transition-colors',
+            scope === 'project'
+              ? 'border-blue-400 bg-blue-100 ring-1 ring-blue-300 dark:border-blue-600 dark:bg-blue-950/60 dark:ring-blue-700'
+              : 'border-border hover:bg-muted/40',
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <FolderKanban
+              className={cn(
+                'h-3.5 w-3.5 shrink-0',
+                scope === 'project'
+                  ? 'text-blue-700 dark:text-blue-400'
+                  : 'text-muted-foreground',
+              )}
+            />
+            <span className="text-sm font-medium">Project-scoped</span>
+          </div>
+          <span className="text-xs text-muted-foreground leading-snug">
+            Locked to a single project only
+          </span>
+        </button>
+      </div>
+
+      {/* Project picker — shown when project-scoped is selected */}
+      {scope === 'project' && (
+        <div className="pt-1">
+          <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+            Select project
+          </label>
+          {isLoading ? (
+            <div className="h-9 rounded-md border border-input bg-muted/30 animate-pulse" />
+          ) : projects.length === 0 ? (
+            <p className="text-xs text-destructive">
+              No projects found in this organisation. Create one first.
+            </p>
+          ) : (
+            <select
+              value={selectedProjectId}
+              onChange={(e) => onProjectChange(e.target.value)}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <option value="">— choose a project —</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface CreateApiKeyDialogProps {
+  orgSlug: string;
+  /** Optional trigger override — renders the default "New API Key" button otherwise */
+  trigger?: React.ReactNode;
+}
+
+export function CreateApiKeyDialog({
+  orgSlug,
+  trigger,
+}: CreateApiKeyDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [revealResult, setRevealResult] = useState<CreateApiKeyResult | null>(
+    null,
+  );
+
+  // Scope state
+  const [scope, setScope] = useState<'org' | 'project'>('org');
+  const [selectedProjectId, setSelectedProjectId] = useState('');
+
+  // Permission rows state
+  const [permRows, setPermRows] = useState<PermRow[]>([freshRow()]);
+
+  const createMutation = useCreateApiKey(orgSlug);
+
+  const form = useForm<CreateKeyForm>({
+    resolver: zodResolver(createKeySchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      rateLimitPerMinute: 1000,
+      expiresAt: '',
+    },
+  });
+
+  // ── Permission row helpers ──
+  const addPermRow = () =>
+    setPermRows((prev) => [
+      ...prev,
+      { ...freshRow(), resourceType: 'PROJECT', permission: 'READ' },
+    ]);
+
+  const removePermRow = (id: number) =>
+    setPermRows((prev) => prev.filter((r) => r.id !== id));
+
+  const updatePermRow = (id: number, patch: Partial<PermRow>) =>
+    setPermRows((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+    );
+
+  // ── Submit ──
+  const onSubmit = async (values: CreateKeyForm) => {
+    if (scope === 'project' && !selectedProjectId) {
+      // Focus the project select
+      return;
+    }
+
+    const permissions = permRows.map((r) => ({
+      resourceType: r.resourceType,
+      permission: r.permission,
+      ...(r.resourceId.trim() ? { resourceId: r.resourceId.trim() } : {}),
+    }));
+
+    const result = await createMutation.mutateAsync({
+      name: values.name,
+      description: values.description || undefined,
+      rateLimitPerMinute: values.rateLimitPerMinute,
+      expiresAt: values.expiresAt || undefined,
+      projectId: scope === 'project' ? selectedProjectId : undefined,
+      permissions,
+    });
+
+    console.log('Created API key', result);
+
+    setRevealResult(result);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setRevealResult(null);
+    form.reset();
+    setScope('org');
+    setSelectedProjectId('');
+    setPermRows([freshRow()]);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => (v ? setOpen(true) : handleClose())}
+    >
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button>
+            <Key className="mr-2 h-4 w-4" />
+            New API Key
+          </Button>
+        )}
+      </DialogTrigger>
+
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        {revealResult ? (
+          /* ── Step 2: show the key once ── */
+          <>
+            <DialogHeader>
+              <DialogTitle>API Key Created</DialogTitle>
+              <DialogDescription>
+                <strong>{revealResult.keyInfo.name}</strong> has been created.
+                {revealResult.keyInfo.projectId ? (
+                  <span className="ml-1 inline-flex items-center gap-1 rounded border border-blue-300 bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-800 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300">
+                    <FolderKanban className="h-3 w-3" />
+                    project-scoped
+                  </span>
+                ) : (
+                  <span className="ml-1 inline-flex items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+                    <Globe className="h-3 w-3" />
+                    org-wide
+                  </span>
+                )}
+              </DialogDescription>
+            </DialogHeader>
+            <KeyReveal plainTextKey={revealResult.apiKey} />
+            <DialogFooter>
+              <Button onClick={handleClose}>Done</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          /* ── Step 1: form ── */
+          <>
+            <DialogHeader>
+              <DialogTitle>Create API Key</DialogTitle>
+              <DialogDescription>
+                Keys allow programmatic access without a user session.
+                Permissions define exactly what the key can read, write, or
+                manage.
+              </DialogDescription>
+            </DialogHeader>
+
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="space-y-5 py-1"
+              >
+                {/* Name */}
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Key name</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="CI/CD pipeline, Mobile app…"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Description */}
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Description{' '}
+                        <span className="font-normal text-muted-foreground">
+                          (optional)
+                        </span>
+                      </FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="What is this key used for?"
+                          className="resize-none"
+                          rows={2}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* ── Scope selector ── */}
+                <div className="rounded-lg border bg-muted/20 p-4 space-y-3">
+                  <ScopeSelector
+                    orgSlug={orgSlug}
+                    scope={scope}
+                    selectedProjectId={selectedProjectId}
+                    onScopeChange={setScope}
+                    onProjectChange={setSelectedProjectId}
+                  />
+                </div>
+
+                {/* Rate limit + expiry */}
+                <div className="grid grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="rateLimitPerMinute"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Rate limit</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={100000}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription className="text-xs">
+                          Requests per minute · default 1 000
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="expiresAt"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          Expiry{' '}
+                          <span className="font-normal text-muted-foreground">
+                            (optional)
+                          </span>
+                        </FormLabel>
+                        <FormControl>
+                          <Input type="datetime-local" {...field} />
+                        </FormControl>
+                        <FormDescription className="text-xs">
+                          Blank = never expires
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* ── Permissions builder ── */}
+                <div className="space-y-3">
+                  <div className="flex items-start justify-between">
+                    <div className="space-y-0.5">
+                      <p className="text-sm font-medium">Permissions</p>
+                      <p className="text-xs text-muted-foreground">
+                        Leave Resource ID blank for wildcard access to all
+                        resources of that type.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={addPermRow}
+                    >
+                      <Plus className="h-3 w-3 mr-1" />
+                      Add
+                    </Button>
+                  </div>
+
+                  <div className="space-y-2">
+                    {/* Column headers */}
+                    <div className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 px-1">
+                      {[
+                        'Resource type',
+                        'Permission',
+                        'Resource ID (optional)',
+                        '',
+                      ].map((h) => (
+                        <p
+                          key={h}
+                          className="text-[11px] font-medium text-muted-foreground"
+                        >
+                          {h}
+                        </p>
+                      ))}
+                    </div>
+
+                    {permRows.map((row) => (
+                      <div
+                        key={row.id}
+                        className="grid grid-cols-[1fr_1fr_1fr_32px] gap-2 items-center rounded-lg border bg-muted/30 p-2"
+                      >
+                        <select
+                          value={row.resourceType}
+                          onChange={(e) =>
+                            updatePermRow(row.id, {
+                              resourceType: e.target.value as ApiResourceType,
+                            })
+                          }
+                          className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        >
+                          {RESOURCE_TYPES.map((t) => (
+                            <option key={t} value={t}>
+                              {t}
+                            </option>
+                          ))}
+                        </select>
+
+                        <select
+                          value={row.permission}
+                          onChange={(e) =>
+                            updatePermRow(row.id, {
+                              permission: e.target.value as ApiPermission,
+                            })
+                          }
+                          className="h-8 w-full rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          title={PERMISSION_HINT[row.permission]}
+                        >
+                          {PERMISSIONS.map((p) => (
+                            <option
+                              key={p}
+                              value={p}
+                              title={PERMISSION_HINT[p]}
+                            >
+                              {p} — {PERMISSION_HINT[p]}
+                            </option>
+                          ))}
+                        </select>
+
+                        <Input
+                          value={row.resourceId}
+                          onChange={(e) =>
+                            updatePermRow(row.id, {
+                              resourceId: e.target.value,
+                            })
+                          }
+                          placeholder="any"
+                          className="h-8 text-xs font-mono"
+                        />
+
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                          onClick={() => removePermRow(row.id)}
+                          disabled={permRows.length === 1}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+
+                  <p className="text-[11px] text-muted-foreground">
+                    Hierarchy:{' '}
+                    <code className="font-mono text-red-600 dark:text-red-400">
+                      ADMIN
+                    </code>{' '}
+                    ≥{' '}
+                    <code className="font-mono text-orange-600 dark:text-orange-400">
+                      DELETE
+                    </code>{' '}
+                    ≥{' '}
+                    <code className="font-mono text-amber-600 dark:text-amber-400">
+                      WRITE
+                    </code>{' '}
+                    ≥{' '}
+                    <code className="font-mono text-blue-600 dark:text-blue-400">
+                      READ
+                    </code>
+                  </p>
+                </div>
+
+                <DialogFooter className="pt-2">
+                  <Button type="button" variant="outline" onClick={handleClose}>
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={
+                      createMutation.isPending ||
+                      (scope === 'project' && !selectedProjectId)
+                    }
+                  >
+                    {createMutation.isPending ? 'Creating…' : 'Create API Key'}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/api-key/CreateApiKeyDialog.tsx
+++ b/src/components/api-key/CreateApiKeyDialog.tsx
@@ -39,12 +39,17 @@ import type {
 const createKeySchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
   description: z.string().max(255).optional(),
-  rateLimitPerMinute: z
+  rateLimitPerMinute: z.coerce
     .number()
-    .int()
+    .int('Must be a whole number')
     .min(1, 'Min 1')
     .max(100_000, 'Max 100 000'),
-  expiresAt: z.string().optional(),
+  expiresAt: z
+    .string()
+    .optional()
+    .refine((val) => !val || new Date(val) > new Date(), {
+      message: 'Expiry date must be in the future',
+    }),
 });
 
 type CreateKeyForm = z.infer<typeof createKeySchema>;
@@ -433,7 +438,11 @@ export function CreateApiKeyDialog({
                           </span>
                         </FormLabel>
                         <FormControl>
-                          <Input type="datetime-local" {...field} />
+                          <Input
+                            type="datetime-local"
+                            min={new Date().toISOString().split('T')[0]}
+                            {...field}
+                          />
                         </FormControl>
                         <FormDescription className="text-xs">
                           Blank = never expires

--- a/src/components/api-key/DeleteKeyDialog.tsx
+++ b/src/components/api-key/DeleteKeyDialog.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { Trash2, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useDeleteApiKey } from '@/hooks/use-api-key';
+import type { ApiKeyResponse } from '@/api/types';
+
+interface DeleteKeyDialogProps {
+  orgSlug: string;
+  apiKey: ApiKeyResponse;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Hard-delete confirmation.
+ * Requires the user to type the key name to confirm, preventing accidental deletion.
+ */
+export function DeleteKeyDialog({
+  orgSlug,
+  apiKey,
+  open,
+  onClose,
+}: DeleteKeyDialogProps) {
+  const [confirmation, setConfirmation] = useState('');
+  const deleteMutation = useDeleteApiKey(orgSlug);
+
+  const isConfirmed = confirmation.trim() === apiKey.name;
+
+  const handleDelete = async () => {
+    if (!isConfirmed) return;
+    await deleteMutation.mutateAsync(apiKey.id);
+    setConfirmation('');
+    onClose();
+  };
+
+  const handleClose = () => {
+    setConfirmation('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <Trash2 className="h-4 w-4" />
+            Delete API Key
+          </DialogTitle>
+          <DialogDescription>
+            This will permanently delete <strong>"{apiKey.name}"</strong>. This
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-100 p-3 dark:border-red-700 dark:bg-red-950/60">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-700 dark:text-red-400" />
+          <p className="text-sm text-red-900 dark:text-red-200">
+            Deleting a key is permanent. All services using{' '}
+            <code className="font-mono text-xs">{apiKey.keyPrefix}</code> will
+            immediately lose access and the key record will be removed.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            Type{' '}
+            <span className="font-semibold text-foreground">{apiKey.name}</span>{' '}
+            to confirm:
+          </p>
+          <Input
+            value={confirmation}
+            onChange={(e) => setConfirmation(e.target.value)}
+            placeholder={apiKey.name}
+            className="font-mono"
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={handleClose}
+            disabled={deleteMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={!isConfirmed || deleteMutation.isPending}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            {deleteMutation.isPending ? 'Deleting…' : 'Delete Permanently'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/api-key/KeyReveal.tsx
+++ b/src/components/api-key/KeyReveal.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Copy, CheckCheck, ShieldAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+
+interface KeyRevealProps {
+  plainTextKey: string;
+  label?: string;
+}
+
+/**
+ * Renders the full API key once (as returned by create/rotate).
+ * The key is displayed in a styled box with a copy button.
+ * After copying, a "Copied!" state is shown briefly.
+ *
+ * UX contract: this component must only be mounted once per key lifecycle.
+ * Once closed/unmounted, the key is gone. The warning reinforces this.
+ */
+export function KeyReveal({
+  plainTextKey,
+  label = 'Your new API key',
+}: KeyRevealProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(plainTextKey);
+      setCopied(true);
+      toast.success('API key copied to clipboard');
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      toast.error('Could not copy — please select and copy manually');
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Warning banner */}
+      <div className="flex items-start gap-2.5 rounded-lg border bg-amber-100 border-amber-300 p-3 dark:border-amber-700 dark:bg-amber-950/60">
+        <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-400" />
+        <div className="text-sm text-amber-900 dark:text-amber-200">
+          <span className="font-semibold">Copy this key now.</span> For
+          security, it will never be shown again after you close this dialog.
+        </div>
+      </div>
+
+      {/* Key display */}
+      <div className="space-y-1.5">
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <div className="group relative flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2.5">
+          <code className="flex-1 break-all font-mono text-xs leading-relaxed select-all text-foreground">
+            {plainTextKey}
+          </code>
+          <Button
+            size="sm"
+            variant={copied ? 'secondary' : 'outline'}
+            className="shrink-0 h-7 px-2 gap-1.5 text-xs"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <>
+                <CheckCheck className="h-3 w-3 text-green-600" />
+                <span className="text-green-600">Copied</span>
+              </>
+            ) : (
+              <>
+                <Copy className="h-3 w-3" />
+                Copy
+              </>
+            )}
+          </Button>
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Use this key in the{' '}
+          <code className="font-mono bg-muted px-1 rounded">X-API-Key</code>{' '}
+          header or{' '}
+          <code className="font-mono bg-muted px-1 rounded">
+            Authorization: ApiKey &lt;key&gt;
+          </code>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/api-key/PermissionBadge.tsx
+++ b/src/components/api-key/PermissionBadge.tsx
@@ -1,0 +1,92 @@
+import { cn } from '@/lib/utils';
+import type { ApiPermission, ApiResourceType } from '@/api/types';
+
+// ------- Colour mapping --------
+const PERMISSION_STYLES: Record<ApiPermission, string> = {
+  READ: 'bg-blue-100   text-blue-800   border-blue-300   dark:bg-blue-950   dark:text-blue-300   dark:border-blue-700',
+  WRITE:
+    'bg-amber-100  text-amber-800  border-amber-300  dark:bg-amber-950  dark:text-amber-300  dark:border-amber-700',
+  DELETE:
+    'bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-950 dark:text-orange-300 dark:border-orange-700',
+  ADMIN:
+    'bg-red-100    text-red-800    border-red-300    dark:bg-red-950    dark:text-red-300    dark:border-red-700',
+};
+
+// -------- Components --------
+
+interface PermissionBadgeProps {
+  resourceType: ApiResourceType;
+  permission: ApiPermission;
+  resourceId?: string;
+  className?: string;
+}
+
+export function PermissionBadge({
+  resourceType,
+  permission,
+  resourceId,
+  className,
+}: PermissionBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 font-mono text-[10px] font-medium leading-none',
+        PERMISSION_STYLES[permission],
+        className,
+      )}
+      title={
+        resourceId
+          ? `Scoped to resource: ${resourceId}`
+          : 'Wildcard (all resources)'
+      }
+    >
+      <span>{resourceType}</span>
+      <span className="opacity-50">·</span>
+      <span className="font-semibold">{permission}</span>
+      {resourceId && <span className="opacity-60 ml-0.5">↗</span>}
+    </span>
+  );
+}
+
+interface PermissionBadgeListProps {
+  permissions: {
+    resourceType: ApiResourceType;
+    permission: ApiPermission;
+    resourceId?: string;
+  }[];
+  maxVisible?: number;
+}
+
+export function PermissionBadgeList({
+  permissions,
+  maxVisible = 3,
+}: PermissionBadgeListProps) {
+  if (permissions.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground italic">
+        No permissions
+      </span>
+    );
+  }
+
+  const visible = permissions.slice(0, maxVisible);
+  const overflow = permissions.length - maxVisible;
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center">
+      {visible.map((p, i) => (
+        <PermissionBadge
+          key={i}
+          resourceType={p.resourceType}
+          permission={p.permission}
+          resourceId={p.resourceId}
+        />
+      ))}
+      {overflow > 0 && (
+        <span className="text-[10px] text-muted-foreground font-medium">
+          +{overflow} more
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/api-key/RevokeKeyDialog.tsx
+++ b/src/components/api-key/RevokeKeyDialog.tsx
@@ -1,0 +1,86 @@
+import { Ban, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useRevokeApiKey } from '@/hooks/use-api-key';
+import type { ApiKeyResponse } from '@/api/types';
+
+interface RevokeKeyDialogProps {
+  orgSlug: string;
+  apiKey: ApiKeyResponse;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function RevokeKeyDialog({
+  orgSlug,
+  apiKey,
+  open,
+  onClose,
+}: RevokeKeyDialogProps) {
+  const revokeMutation = useRevokeApiKey(orgSlug);
+
+  const handleRevoke = async () => {
+    await revokeMutation.mutateAsync(apiKey.id);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Ban className="h-4 w-4 text-destructive" />
+            Revoke API Key
+          </DialogTitle>
+          <DialogDescription>
+            Revoke <strong>"{apiKey.name}"</strong>?
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-100 p-3 dark:border-red-700 dark:bg-red-950/60">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-700 dark:text-red-400" />
+          <div className="text-sm text-red-900 dark:text-red-200 space-y-1">
+            <p className="font-semibold">
+              The key will stop working immediately.
+            </p>
+            <p>
+              The key{' '}
+              <code className="font-mono text-xs">{apiKey.keyPrefix}</code> will
+              be deactivated. It will remain visible in this list but can no
+              longer authenticate requests.
+            </p>
+            <p className="text-red-800/70 dark:text-red-300/70">
+              Tip: if this is a leaked key, consider deleting it entirely after
+              revoking.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={revokeMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleRevoke}
+            disabled={revokeMutation.isPending}
+          >
+            <Ban className="mr-2 h-4 w-4" />
+            {revokeMutation.isPending ? 'Revoking…' : 'Revoke Key'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/api-key/RotateKeyDialog.tsx
+++ b/src/components/api-key/RotateKeyDialog.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { RefreshCw, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useRotateApiKey } from '@/hooks/use-api-key';
+import { KeyReveal } from './KeyReveal';
+import type { ApiKeyResponse, CreateApiKeyResult } from '@/api/types';
+import { toast } from 'sonner';
+
+interface RotateKeyDialogProps {
+  orgSlug: string;
+  apiKey: ApiKeyResponse;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function RotateKeyDialog({
+  orgSlug,
+  apiKey,
+  open,
+  onClose,
+}: RotateKeyDialogProps) {
+  const [revealResult, setRevealResult] = useState<CreateApiKeyResult | null>(
+    null,
+  );
+  const rotateMutation = useRotateApiKey(orgSlug);
+
+  const handleRotate = async () => {
+    const result = await rotateMutation.mutateAsync(apiKey.id);
+    setRevealResult(result);
+    toast.success('API key rotated — old key is now invalid');
+  };
+
+  const handleClose = () => {
+    setRevealResult(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent className="max-w-lg">
+        {revealResult ? (
+          /* Step 2: show new key */
+          <>
+            <DialogHeader>
+              <DialogTitle>Key Rotated</DialogTitle>
+              <DialogDescription>
+                <strong>{apiKey.name}</strong> now uses a new secret. The old
+                key is invalid.
+              </DialogDescription>
+            </DialogHeader>
+            <KeyReveal
+              plainTextKey={revealResult.apiKey}
+              label="New API key — copy it now"
+            />
+            <DialogFooter>
+              <Button onClick={handleClose}>Done</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          /* Step 1: confirmation */
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <RefreshCw className="h-4 w-4" />
+                Rotate API Key
+              </DialogTitle>
+              <DialogDescription>
+                You are about to rotate <strong>"{apiKey.name}"</strong>.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex items-start gap-3 rounded-lg border border-orange-300 bg-orange-100 p-3 dark:border-orange-700 dark:bg-orange-950/60">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-orange-700 dark:text-orange-400" />
+              <div className="text-sm text-orange-900 dark:text-orange-200 space-y-1">
+                <p className="font-semibold">This action is immediate.</p>
+                <p>
+                  The current key (
+                  <code className="font-mono text-xs">{apiKey.keyPrefix}</code>)
+                  will stop working instantly. Any service using this key must
+                  be updated with the new value.
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={handleClose}
+                disabled={rotateMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleRotate}
+                disabled={rotateMutation.isPending}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                {rotateMutation.isPending ? 'Rotating…' : 'Rotate Key'}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/use-api-key.ts
+++ b/src/hooks/use-api-key.ts
@@ -1,0 +1,151 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { apiKeysApi } from '@/api/api-key';
+import type { CreateApiKeyRequest, UpdateApiKeyRequest } from '@/api/types';
+
+// ------- Query key factory -------
+
+export const apiKeysKeys = {
+  all: (orgSlug: string) => ['api-keys', orgSlug] as const,
+  detail: (orgSlug: string, keyId: string) =>
+    ['api-keys', orgSlug, keyId] as const,
+};
+
+// ------- Queries -------
+
+export function useApiKeys(orgSlug: string) {
+  return useQuery({
+    queryKey: apiKeysKeys.all(orgSlug),
+    queryFn: () => apiKeysApi.list(orgSlug),
+    enabled: !!orgSlug,
+    staleTime: 30_000, // keys list is fairly stable
+  });
+}
+
+export function useApiKey(orgSlug: string, keyId: string) {
+  return useQuery({
+    queryKey: apiKeysKeys.detail(orgSlug, keyId),
+    queryFn: () => apiKeysApi.getById(orgSlug, keyId),
+    enabled: !!orgSlug && !!keyId,
+  });
+}
+
+// ------- Mutations -------
+
+export function useCreateApiKey(orgSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateApiKeyRequest) => apiKeysApi.create(orgSlug, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+      // Note: toast is shown by the component so it can show the key reveal
+    },
+    onError: (err: any) => {
+      toast.error(err.response?.data?.message || 'Failed to create API key');
+    },
+  });
+}
+
+export function useUpdateApiKey(orgSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      keyId,
+      data,
+    }: {
+      keyId: string;
+      data: UpdateApiKeyRequest;
+    }) => apiKeysApi.update(orgSlug, keyId, data),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(
+        apiKeysKeys.detail(orgSlug, updated.id),
+        updated,
+      );
+      queryClient.invalidateQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+      toast.success('API key updated');
+    },
+    onError: (err: any) => {
+      toast.error(err.response?.data?.message || 'Failed to update API key');
+    },
+  });
+}
+
+export function useRevokeApiKey(orgSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (keyId: string) => apiKeysApi.revoke(orgSlug, keyId),
+    // Optimistic update: immediately mark as inactive in the list cache
+    onMutate: async (keyId) => {
+      await queryClient.cancelQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+      const previous = queryClient.getQueryData(apiKeysKeys.all(orgSlug));
+      queryClient.setQueryData(apiKeysKeys.all(orgSlug), (old: any[] = []) =>
+        old.map((k) => (k.id === keyId ? { ...k, active: false } : k)),
+      );
+      return { previous };
+    },
+    onSuccess: () => {
+      toast.success('API key revoked');
+    },
+    onError: (err: any, _keyId, ctx) => {
+      // Roll back optimistic update on error
+      if (ctx?.previous) {
+        queryClient.setQueryData(apiKeysKeys.all(orgSlug), ctx.previous);
+      }
+      toast.error(err.response?.data?.message || 'Failed to revoke API key');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+    },
+  });
+}
+
+export function useDeleteApiKey(orgSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (keyId: string) => apiKeysApi.delete(orgSlug, keyId),
+    // Optimistic update: remove from list immediately
+    onMutate: async (keyId) => {
+      await queryClient.cancelQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+      const previous = queryClient.getQueryData(apiKeysKeys.all(orgSlug));
+      queryClient.setQueryData(apiKeysKeys.all(orgSlug), (old: any[] = []) =>
+        old.filter((k) => k.id !== keyId),
+      );
+      return { previous };
+    },
+    onSuccess: () => {
+      toast.success('API key deleted');
+    },
+    onError: (err: any, _keyId, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(apiKeysKeys.all(orgSlug), ctx.previous);
+      }
+      toast.error(err.response?.data?.message || 'Failed to delete API key');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+    },
+  });
+}
+
+export function useRotateApiKey(orgSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (keyId: string) => apiKeysApi.rotate(orgSlug, keyId),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: apiKeysKeys.all(orgSlug) });
+      queryClient.setQueryData(
+        apiKeysKeys.detail(orgSlug, result.keyInfo.id),
+        result.keyInfo,
+      );
+      // toast shown by component so it can also show the new key reveal
+    },
+    onError: (err: any) => {
+      toast.error(err.response?.data?.message || 'Failed to rotate API key');
+    },
+  });
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,8 +22,9 @@ import { Route as AuthResetPasswordRouteImport } from './routes/_auth/reset-pass
 import { Route as AuthRegisterRouteImport } from './routes/_auth/register'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as ProtectedOrganizationsIndexRouteImport } from './routes/_protected/organizations/index'
-import { Route as ProtectedOrganizationsOrgSlugRouteImport } from './routes/_protected/organizations/$orgSlug'
+import { Route as ProtectedOrganizationsOrgSlugIndexRouteImport } from './routes/_protected/organizations/$orgSlug/index'
 import { Route as ProtectedProjectsOrgSlugProjectSlugRouteImport } from './routes/_protected/_projects/$orgSlug/$projectSlug'
+import { Route as ProtectedOrganizationsOrgSlugApiKeysIndexRouteImport } from './routes/_protected/organizations/$orgSlug/api-keys/index'
 import { Route as ProtectedSchemasOrgSlugProjectSlugSchemaSlugRouteImport } from './routes/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug'
 
 const SplatRoute = SplatRouteImport.update({
@@ -89,16 +90,22 @@ const ProtectedOrganizationsIndexRoute =
     path: '/organizations/',
     getParentRoute: () => ProtectedRouteRoute,
   } as any)
-const ProtectedOrganizationsOrgSlugRoute =
-  ProtectedOrganizationsOrgSlugRouteImport.update({
-    id: '/organizations/$orgSlug',
-    path: '/organizations/$orgSlug',
+const ProtectedOrganizationsOrgSlugIndexRoute =
+  ProtectedOrganizationsOrgSlugIndexRouteImport.update({
+    id: '/organizations/$orgSlug/',
+    path: '/organizations/$orgSlug/',
     getParentRoute: () => ProtectedRouteRoute,
   } as any)
 const ProtectedProjectsOrgSlugProjectSlugRoute =
   ProtectedProjectsOrgSlugProjectSlugRouteImport.update({
     id: '/_projects/$orgSlug/$projectSlug',
     path: '/$orgSlug/$projectSlug',
+    getParentRoute: () => ProtectedRouteRoute,
+  } as any)
+const ProtectedOrganizationsOrgSlugApiKeysIndexRoute =
+  ProtectedOrganizationsOrgSlugApiKeysIndexRouteImport.update({
+    id: '/organizations/$orgSlug/api-keys/',
+    path: '/organizations/$orgSlug/api-keys/',
     getParentRoute: () => ProtectedRouteRoute,
   } as any)
 const ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute =
@@ -118,10 +125,11 @@ export interface FileRoutesByFullPath {
   '/verify-email': typeof PublicVerifyEmailRoute
   '/oauth2/redirect': typeof Oauth2RedirectRoute
   '/': typeof PublicIndexRoute
-  '/organizations/$orgSlug': typeof ProtectedOrganizationsOrgSlugRoute
   '/organizations': typeof ProtectedOrganizationsIndexRoute
   '/$orgSlug/$projectSlug': typeof ProtectedProjectsOrgSlugProjectSlugRoute
+  '/organizations/$orgSlug': typeof ProtectedOrganizationsOrgSlugIndexRoute
   '/$orgSlug/$projectSlug/$schemaSlug': typeof ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute
+  '/organizations/$orgSlug/api-keys': typeof ProtectedOrganizationsOrgSlugApiKeysIndexRoute
 }
 export interface FileRoutesByTo {
   '/$': typeof SplatRoute
@@ -133,10 +141,11 @@ export interface FileRoutesByTo {
   '/verify-email': typeof PublicVerifyEmailRoute
   '/oauth2/redirect': typeof Oauth2RedirectRoute
   '/': typeof PublicIndexRoute
-  '/organizations/$orgSlug': typeof ProtectedOrganizationsOrgSlugRoute
   '/organizations': typeof ProtectedOrganizationsIndexRoute
   '/$orgSlug/$projectSlug': typeof ProtectedProjectsOrgSlugProjectSlugRoute
+  '/organizations/$orgSlug': typeof ProtectedOrganizationsOrgSlugIndexRoute
   '/$orgSlug/$projectSlug/$schemaSlug': typeof ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute
+  '/organizations/$orgSlug/api-keys': typeof ProtectedOrganizationsOrgSlugApiKeysIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -152,10 +161,11 @@ export interface FileRoutesById {
   '/_public/verify-email': typeof PublicVerifyEmailRoute
   '/oauth2/redirect': typeof Oauth2RedirectRoute
   '/_public/': typeof PublicIndexRoute
-  '/_protected/organizations/$orgSlug': typeof ProtectedOrganizationsOrgSlugRoute
   '/_protected/organizations/': typeof ProtectedOrganizationsIndexRoute
   '/_protected/_projects/$orgSlug/$projectSlug': typeof ProtectedProjectsOrgSlugProjectSlugRoute
+  '/_protected/organizations/$orgSlug/': typeof ProtectedOrganizationsOrgSlugIndexRoute
   '/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug': typeof ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute
+  '/_protected/organizations/$orgSlug/api-keys/': typeof ProtectedOrganizationsOrgSlugApiKeysIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -169,10 +179,11 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/oauth2/redirect'
     | '/'
-    | '/organizations/$orgSlug'
     | '/organizations'
     | '/$orgSlug/$projectSlug'
+    | '/organizations/$orgSlug'
     | '/$orgSlug/$projectSlug/$schemaSlug'
+    | '/organizations/$orgSlug/api-keys'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/$'
@@ -184,10 +195,11 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/oauth2/redirect'
     | '/'
-    | '/organizations/$orgSlug'
     | '/organizations'
     | '/$orgSlug/$projectSlug'
+    | '/organizations/$orgSlug'
     | '/$orgSlug/$projectSlug/$schemaSlug'
+    | '/organizations/$orgSlug/api-keys'
   id:
     | '__root__'
     | '/_auth'
@@ -202,10 +214,11 @@ export interface FileRouteTypes {
     | '/_public/verify-email'
     | '/oauth2/redirect'
     | '/_public/'
-    | '/_protected/organizations/$orgSlug'
     | '/_protected/organizations/'
     | '/_protected/_projects/$orgSlug/$projectSlug'
+    | '/_protected/organizations/$orgSlug/'
     | '/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug'
+    | '/_protected/organizations/$orgSlug/api-keys/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -309,11 +322,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedOrganizationsIndexRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
-    '/_protected/organizations/$orgSlug': {
-      id: '/_protected/organizations/$orgSlug'
+    '/_protected/organizations/$orgSlug/': {
+      id: '/_protected/organizations/$orgSlug/'
       path: '/organizations/$orgSlug'
       fullPath: '/organizations/$orgSlug'
-      preLoaderRoute: typeof ProtectedOrganizationsOrgSlugRouteImport
+      preLoaderRoute: typeof ProtectedOrganizationsOrgSlugIndexRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
     '/_protected/_projects/$orgSlug/$projectSlug': {
@@ -321,6 +334,13 @@ declare module '@tanstack/react-router' {
       path: '/$orgSlug/$projectSlug'
       fullPath: '/$orgSlug/$projectSlug'
       preLoaderRoute: typeof ProtectedProjectsOrgSlugProjectSlugRouteImport
+      parentRoute: typeof ProtectedRouteRoute
+    }
+    '/_protected/organizations/$orgSlug/api-keys/': {
+      id: '/_protected/organizations/$orgSlug/api-keys/'
+      path: '/organizations/$orgSlug/api-keys'
+      fullPath: '/organizations/$orgSlug/api-keys'
+      preLoaderRoute: typeof ProtectedOrganizationsOrgSlugApiKeysIndexRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
     '/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug': {
@@ -351,20 +371,24 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 
 interface ProtectedRouteRouteChildren {
   ProtectedDashboardRoute: typeof ProtectedDashboardRoute
-  ProtectedOrganizationsOrgSlugRoute: typeof ProtectedOrganizationsOrgSlugRoute
   ProtectedOrganizationsIndexRoute: typeof ProtectedOrganizationsIndexRoute
   ProtectedProjectsOrgSlugProjectSlugRoute: typeof ProtectedProjectsOrgSlugProjectSlugRoute
+  ProtectedOrganizationsOrgSlugIndexRoute: typeof ProtectedOrganizationsOrgSlugIndexRoute
   ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute: typeof ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute
+  ProtectedOrganizationsOrgSlugApiKeysIndexRoute: typeof ProtectedOrganizationsOrgSlugApiKeysIndexRoute
 }
 
 const ProtectedRouteRouteChildren: ProtectedRouteRouteChildren = {
   ProtectedDashboardRoute: ProtectedDashboardRoute,
-  ProtectedOrganizationsOrgSlugRoute: ProtectedOrganizationsOrgSlugRoute,
   ProtectedOrganizationsIndexRoute: ProtectedOrganizationsIndexRoute,
   ProtectedProjectsOrgSlugProjectSlugRoute:
     ProtectedProjectsOrgSlugProjectSlugRoute,
+  ProtectedOrganizationsOrgSlugIndexRoute:
+    ProtectedOrganizationsOrgSlugIndexRoute,
   ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute:
     ProtectedSchemasOrgSlugProjectSlugSchemaSlugRoute,
+  ProtectedOrganizationsOrgSlugApiKeysIndexRoute:
+    ProtectedOrganizationsOrgSlugApiKeysIndexRoute,
 }
 
 const ProtectedRouteRouteWithChildren = ProtectedRouteRoute._addFileChildren(

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -1,8 +1,28 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  Key,
+  ArrowLeft,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Globe,
+  FolderKanban,
+  AlertCircle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { useApiKeys } from '@/hooks/use-api-key';
-import type { ApiKeyResponse } from '@/api/types';
-import { ApiKeyTable } from '@/components/api-key/ApiKeyTable';
 import { useProjects } from '@/hooks/use-projects';
+import {
+  ApiKeyTable,
+  ApiKeyTableSkeleton,
+} from '@/components/api-key/ApiKeyTable';
 import { CreateApiKeyDialog } from '@/components/api-key/CreateApiKeyDialog';
 
 export const Route = createFileRoute(
@@ -11,7 +31,136 @@ export const Route = createFileRoute(
   component: ApiKeysPage,
 });
 
-function StatsRow({ keys }: { keys: ApiKeyResponse[] }) {
+// ---- Stats Row -------
+
+function StatsRow({
+  total,
+  active,
+  revoked,
+  expired,
+  orgWide,
+  projectScoped,
+}: {
+  total: number;
+  active: number;
+  revoked: number;
+  expired: number;
+  orgWide: number;
+  projectScoped: number;
+}) {
+  return (
+    <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
+      {[
+        { label: 'Total', value: total, icon: Key, color: '' },
+        {
+          label: 'Active',
+          value: active,
+          icon: CheckCircle2,
+          color: 'text-green-600 dark:text-green-400',
+        },
+        {
+          label: 'Revoked',
+          value: revoked,
+          icon: XCircle,
+          color: 'text-red-600 dark:text-red-400',
+        },
+        {
+          label: 'Expired',
+          value: expired,
+          icon: Clock,
+          color: 'text-orange-600 dark:text-orange-400',
+        },
+        {
+          label: 'Org-wide',
+          value: orgWide,
+          icon: Globe,
+          color: 'text-muted-foreground',
+        },
+        {
+          label: 'Project-scoped',
+          value: projectScoped,
+          icon: FolderKanban,
+          color: 'text-primary',
+        },
+      ].map(({ label, value, icon: Icon, color }) => (
+        <div
+          key={label}
+          className="rounded-lg bg-muted/40 border px-3 py-3 space-y-1"
+        >
+          <p className="text-[11px] text-muted-foreground">{label}</p>
+          <div className={`flex items-center gap-1.5 ${color}`}>
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            <span className="text-xl font-semibold">{value}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---- Empty State ----
+
+function EmptyState({ orgSlug }: { orgSlug: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center justify-center py-16 text-center gap-4">
+        <div className="rounded-full bg-muted p-4">
+          <Key className="h-8 w-8 text-muted-foreground" />
+        </div>
+        <div className="space-y-1 max-w-sm">
+          <h3 className="text-lg font-semibold">No API keys yet</h3>
+          <p className="text-sm text-muted-foreground">
+            Create an org-wide key for broad access, or a project-scoped key to
+            limit access to a single project.
+          </p>
+        </div>
+
+        <div className="rounded-lg border bg-muted/50 px-4 py-3 text-left w-full max-w-sm font-mono text-xs text-muted-foreground">
+          <p className="mb-1 font-sans text-[11px] font-medium">Usage</p>
+          X-API-Key: mk_live_...
+        </div>
+
+        <CreateApiKeyDialog orgSlug={orgSlug} />
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---- Error State ----
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center justify-center py-12 gap-3">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <div className="text-center">
+          <p className="font-medium">Failed to load API keys</p>
+          <p className="text-sm text-muted-foreground">
+            Check your connection and try again.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ApiKeysPage() {
+  const { orgSlug } = Route.useParams();
+  const { data: keys = [], isLoading, isError, refetch } = useApiKeys(orgSlug);
+
+  // Fetch projects so we can resolve projectId → projectName in the table.
+  // useProjects is already used in the org detail page — data is cached.
+  const { data: projects = [] } = useProjects(orgSlug);
+
+  // Build a lookup map once
+  const projectNames: Record<string, string> = Object.fromEntries(
+    projects.map((p) => [p.id, p.name]),
+  );
+
+  // Derived stats
   const now = new Date();
   const expired = keys.filter(
     (k) => k.expiresAt && new Date(k.expiresAt) < now,
@@ -19,73 +168,119 @@ function StatsRow({ keys }: { keys: ApiKeyResponse[] }) {
   const revoked = keys.filter((k) => !k.active).length;
   const active = keys.length - revoked - expired;
   const orgWide = keys.filter((k) => !k.projectId).length;
-  const projScoped = keys.filter((k) => !!k.projectId).length;
+  const projectScoped = keys.filter((k) => !!k.projectId).length;
 
-  const stats = [
-    { label: 'Total', value: keys.length, color: '' },
-    {
-      label: 'Active',
-      value: active,
-      color: 'text-green-700 dark:text-green-400',
-    },
-    {
-      label: 'Revoked',
-      value: revoked,
-      color: 'text-red-700 dark:text-red-400',
-    },
-    {
-      label: 'Expired',
-      value: expired,
-      color: 'text-orange-700 dark:text-orange-400',
-    },
-    { label: 'Org-wide', value: orgWide, color: 'text-muted-foreground' },
-    {
-      label: 'Project-scoped',
-      value: projScoped,
-      color: 'text-blue-700 dark:text-blue-400',
-    },
-  ];
-
-  return (
-    <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
-      {stats.map(({ label, value, color }) => (
-        <div
-          key={label}
-          className="rounded-lg border bg-muted/40 px-3 py-3 space-y-1"
-        >
-          <p className="text-[11px] text-muted-foreground">{label}</p>
-          <p className={`text-xl font-semibold ${color}`}>{value}</p>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function ApiKeysPage() {
-  const { orgSlug } = Route.useParams();
-  const { data: keys = [], isLoading, isError } = useApiKeys(orgSlug);
-
-  const { data: projects = [] } = useProjects(orgSlug);
-  const projectNames: Record<string, string> = Object.fromEntries(
-    projects.map((p) => [p.id, p.name]),
-  );
   return (
     <div className="space-y-6">
+      {/* ── Breadcrumb + header ── */}
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">API Keys</h1>
+        <Link to="/organizations/$orgSlug" params={{ orgSlug }}>
+          <Button variant="ghost" size="sm" className="mb-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to {orgSlug}
+          </Button>
+        </Link>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2.5">
+              <Key className="h-6 w-6 text-primary" />
+              API Keys
+            </h1>
+            <p className="text-muted-foreground">
+              Programmatic access for{' '}
+              <span className="font-medium text-foreground">{orgSlug}</span>.
+              Create org-wide keys or lock a key to a single project.
+            </p>
+          </div>
+
+          {!isLoading && !isError && keys.length > 0 && (
+            <CreateApiKeyDialog orgSlug={orgSlug} />
+          )}
+        </div>
       </div>
 
-      {!isLoading && !isError && <CreateApiKeyDialog orgSlug={orgSlug} />}
+      {/* ── Info notice ── */}
+      <div className="flex items-start gap-2.5 rounded-lg border border-blue-300 bg-blue-100 px-4 py-3 dark:border-blue-700 dark:bg-blue-950/50">
+        <Key className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-700 dark:text-blue-400" />
+        <p className="text-xs text-blue-900 dark:text-blue-200">
+          Key management requires a user session (JWT). API keys cannot manage
+          other API keys.{' '}
+          <span className="text-blue-800/70 dark:text-blue-300/70">
+            Rate limit headers on every response:{' '}
+            <code className="font-mono">X-RateLimit-Limit</code>,{' '}
+            <code className="font-mono">X-RateLimit-Remaining</code>,{' '}
+            <code className="font-mono">Retry-After</code> on 429.
+          </span>
+        </p>
+      </div>
 
-      {!isLoading && !isError && keys.length > 0 && <StatsRow keys={keys} />}
-
+      {/* ── Stats ── */}
       {!isLoading && !isError && keys.length > 0 && (
-        <ApiKeyTable
-          orgSlug={orgSlug}
-          keys={keys}
-          projectNames={projectNames}
+        <StatsRow
+          total={keys.length}
+          active={active}
+          revoked={revoked}
+          expired={expired}
+          orgWide={orgWide}
+          projectScoped={projectScoped}
         />
       )}
+
+      {/* ── Content ── */}
+      <div className="space-y-3">
+        {!isLoading && !isError && keys.length > 0 && (
+          <p className="text-sm font-medium text-muted-foreground">
+            {keys.length} key{keys.length !== 1 ? 's' : ''}
+          </p>
+        )}
+
+        {isLoading && <ApiKeyTableSkeleton />}
+
+        {isError && <ErrorState onRetry={refetch} />}
+
+        {!isLoading && !isError && keys.length === 0 && (
+          <EmptyState orgSlug={orgSlug} />
+        )}
+
+        {!isLoading && !isError && keys.length > 0 && (
+          <ApiKeyTable
+            orgSlug={orgSlug}
+            keys={keys}
+            projectNames={projectNames}
+          />
+        )}
+      </div>
+
+      {/* ── Usage reference ── */}
+      <Card className="bg-muted/30 border-dashed">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">
+            How to authenticate with a key
+          </CardTitle>
+          <CardDescription className="text-xs">
+            Both methods work. Use whichever fits your HTTP client.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid md:grid-cols-2 gap-3">
+          <div>
+            <p className="text-[11px] font-medium text-muted-foreground mb-1">
+              Header
+            </p>
+            <code className="font-mono text-xs bg-background border rounded-md px-2.5 py-1.5 block">
+              X-API-Key: mk_live_…
+            </code>
+          </div>
+          <div>
+            <p className="text-[11px] font-medium text-muted-foreground mb-1">
+              Authorization header
+            </p>
+            <code className="font-mono text-xs bg-background border rounded-md px-2.5 py-1.5 block">
+              Authorization: ApiKey mk_live_…
+            </code>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -1,11 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useApiKeys } from '@/hooks/use-api-key';
 import type { ApiKeyResponse } from '@/api/types';
-import {
-  PermissionBadge,
-  PermissionBadgeList,
-} from '@/components/api-key/PermissionBadge';
-import { KeyReveal } from '@/components/api-key/KeyReveal';
+import { ApiKeyTable } from '@/components/api-key/ApiKeyTable';
+import { useProjects } from '@/hooks/use-projects';
 
 export const Route = createFileRoute(
   '/_protected/organizations/$orgSlug/api-keys/',
@@ -67,6 +64,10 @@ function ApiKeysPage() {
   const { orgSlug } = Route.useParams();
   const { data: keys = [], isLoading, isError } = useApiKeys(orgSlug);
 
+  const { data: projects = [] } = useProjects(orgSlug);
+  const projectNames: Record<string, string> = Object.fromEntries(
+    projects.map((p) => [p.id, p.name]),
+  );
   return (
     <div className="space-y-6">
       <div>
@@ -78,14 +79,13 @@ function ApiKeysPage() {
 
       {!isLoading && !isError && keys.length > 0 && <StatsRow keys={keys} />}
 
-      <div className="flex flex-wrap gap-2 p-4 border rounded-lg">
-        <PermissionBadge resourceType="ORGANIZATION" permission="ADMIN" />
-        <PermissionBadge resourceType="PROJECT" permission="WRITE" />
-        <PermissionBadge resourceType="SCHEMA" permission="READ" />
-        <PermissionBadge resourceType="RECORD" permission="DELETE" />
-      </div>
-
-      <KeyReveal plainTextKey="mk_live_xK8mPqN2vTdR5hYjW1cAeUfBgLsOiZn" />
+      {!isLoading && !isError && keys.length > 0 && (
+        <ApiKeyTable
+          orgSlug={orgSlug}
+          keys={keys}
+          projectNames={projectNames}
+        />
+      )}
     </div>
   );
 }

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -3,6 +3,7 @@ import { useApiKeys } from '@/hooks/use-api-key';
 import type { ApiKeyResponse } from '@/api/types';
 import { ApiKeyTable } from '@/components/api-key/ApiKeyTable';
 import { useProjects } from '@/hooks/use-projects';
+import { CreateApiKeyDialog } from '@/components/api-key/CreateApiKeyDialog';
 
 export const Route = createFileRoute(
   '/_protected/organizations/$orgSlug/api-keys/',
@@ -72,10 +73,9 @@ function ApiKeysPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">API Keys</h1>
-        <p className="text-muted-foreground">
-          Managing keys for <strong>{orgSlug}</strong>
-        </p>
       </div>
+
+      {!isLoading && !isError && <CreateApiKeyDialog orgSlug={orgSlug} />}
 
       {!isLoading && !isError && keys.length > 0 && <StatsRow keys={keys} />}
 

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -1,11 +1,67 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useApiKeys } from '@/hooks/use-api-key';
+import type { ApiKeyResponse } from '@/api/types';
+import {
+  PermissionBadge,
+  PermissionBadgeList,
+} from '@/components/api-key/PermissionBadge';
+import { KeyReveal } from '@/components/api-key/KeyReveal';
 
 export const Route = createFileRoute(
   '/_protected/organizations/$orgSlug/api-keys/',
 )({
   component: ApiKeysPage,
 });
+
+function StatsRow({ keys }: { keys: ApiKeyResponse[] }) {
+  const now = new Date();
+  const expired = keys.filter(
+    (k) => k.expiresAt && new Date(k.expiresAt) < now,
+  ).length;
+  const revoked = keys.filter((k) => !k.isActive).length;
+  const active = keys.length - revoked - expired;
+  const orgWide = keys.filter((k) => !k.projectId).length;
+  const projScoped = keys.filter((k) => !!k.projectId).length;
+
+  const stats = [
+    { label: 'Total', value: keys.length, color: '' },
+    {
+      label: 'Active',
+      value: active,
+      color: 'text-green-700 dark:text-green-400',
+    },
+    {
+      label: 'Revoked',
+      value: revoked,
+      color: 'text-red-700 dark:text-red-400',
+    },
+    {
+      label: 'Expired',
+      value: expired,
+      color: 'text-orange-700 dark:text-orange-400',
+    },
+    { label: 'Org-wide', value: orgWide, color: 'text-muted-foreground' },
+    {
+      label: 'Project-scoped',
+      value: projScoped,
+      color: 'text-blue-700 dark:text-blue-400',
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
+      {stats.map(({ label, value, color }) => (
+        <div
+          key={label}
+          className="rounded-lg border bg-muted/40 px-3 py-3 space-y-1"
+        >
+          <p className="text-[11px] text-muted-foreground">{label}</p>
+          <p className={`text-xl font-semibold ${color}`}>{value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function ApiKeysPage() {
   const { orgSlug } = Route.useParams();
@@ -20,11 +76,16 @@ function ApiKeysPage() {
         </p>
       </div>
 
-      {isLoading && <p className="text-muted-foreground">Loading…</p>}
-      {isError && <p className="text-destructive">Failed to load keys.</p>}
-      {!isLoading && !isError && (
-        <p className="text-muted-foreground">{keys.length} key(s) found</p>
-      )}
+      {!isLoading && !isError && keys.length > 0 && <StatsRow keys={keys} />}
+
+      <div className="flex flex-wrap gap-2 p-4 border rounded-lg">
+        <PermissionBadge resourceType="ORGANIZATION" permission="ADMIN" />
+        <PermissionBadge resourceType="PROJECT" permission="WRITE" />
+        <PermissionBadge resourceType="SCHEMA" permission="READ" />
+        <PermissionBadge resourceType="RECORD" permission="DELETE" />
+      </div>
+
+      <KeyReveal plainTextKey="mk_live_xK8mPqN2vTdR5hYjW1cAeUfBgLsOiZn" />
     </div>
   );
 }

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -163,10 +163,13 @@ function ApiKeysPage() {
   // Derived stats
   const now = new Date();
   const expired = keys.filter(
-    (k) => k.expiresAt && new Date(k.expiresAt) < now,
+    (k) => k.active && k.expiresAt && new Date(k.expiresAt) < now,
   ).length;
   const revoked = keys.filter((k) => !k.active).length;
-  const active = keys.length - revoked - expired;
+  const active = keys.filter(
+    (k) => k.active && !(k.expiresAt && new Date(k.expiresAt) < now),
+  ).length;
+
   const orgWide = keys.filter((k) => !k.projectId).length;
   const projectScoped = keys.filter((k) => !!k.projectId).length;
 

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useApiKeys } from '@/hooks/use-api-key';
 
 export const Route = createFileRoute(
   '/_protected/organizations/$orgSlug/api-keys/',
@@ -8,6 +9,7 @@ export const Route = createFileRoute(
 
 function ApiKeysPage() {
   const { orgSlug } = Route.useParams();
+  const { data: keys = [], isLoading, isError } = useApiKeys(orgSlug);
 
   return (
     <div className="space-y-6">
@@ -17,7 +19,12 @@ function ApiKeysPage() {
           Managing keys for <strong>{orgSlug}</strong>
         </p>
       </div>
-      <p className="text-muted-foreground">Workin on it…</p>
+
+      {isLoading && <p className="text-muted-foreground">Loading…</p>}
+      {isError && <p className="text-destructive">Failed to load keys.</p>}
+      {!isLoading && !isError && (
+        <p className="text-muted-foreground">{keys.length} key(s) found</p>
+      )}
     </div>
   );
 }

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute(
+  '/_protected/organizations/$orgSlug/api-keys/',
+)({
+  component: ApiKeysPage,
+});
+
+function ApiKeysPage() {
+  const { orgSlug } = Route.useParams();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">API Keys</h1>
+        <p className="text-muted-foreground">
+          Managing keys for <strong>{orgSlug}</strong>
+        </p>
+      </div>
+      <p className="text-muted-foreground">Workin on it…</p>
+    </div>
+  );
+}

--- a/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/api-keys/index.tsx
@@ -15,7 +15,7 @@ function StatsRow({ keys }: { keys: ApiKeyResponse[] }) {
   const expired = keys.filter(
     (k) => k.expiresAt && new Date(k.expiresAt) < now,
   ).length;
-  const revoked = keys.filter((k) => !k.isActive).length;
+  const revoked = keys.filter((k) => !k.active).length;
   const active = keys.length - revoked - expired;
   const orgWide = keys.filter((k) => !k.projectId).length;
   const projScoped = keys.filter((k) => !!k.projectId).length;

--- a/src/routes/_protected/organizations/$orgSlug/index.tsx
+++ b/src/routes/_protected/organizations/$orgSlug/index.tsx
@@ -26,8 +26,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Plus, FolderKanban, Database, Trash2, ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatRelativeTime } from '@/lib/utils';
+import { Key } from 'lucide-react';
 
-export const Route = createFileRoute('/_protected/organizations/$orgSlug')({
+export const Route = createFileRoute('/_protected/organizations/$orgSlug/')({
   component: OrganizationDetail,
 });
 
@@ -47,16 +48,13 @@ export function OrganizationDetail() {
     }
 
     await createProjectMutation.mutateAsync({
-      name: projectName ,
+      name: projectName,
     });
     setProjectName('');
     setIsCreateOpen(false);
   };
 
-  const handleDeleteProject = async (
-    projectSlug: string,
-    name: string,
-  ) => {
+  const handleDeleteProject = async (projectSlug: string, name: string) => {
     if (confirm(`Are you sure you want to delete "${name}"?`)) {
       await deleteProjectMutation.mutateAsync(projectSlug);
     }
@@ -98,58 +96,68 @@ export function OrganizationDetail() {
           </Button>
         </Link>
 
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-4">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">
               {organization.name}
             </h1>
             <p className="text-muted-foreground">
-              Owned by {organization.owner.name} • Created{' '}
+              Owned by {organization.owner.name} · Created{' '}
               {formatRelativeTime(organization.createdAt)}
             </p>
           </div>
 
-          <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
-            <DialogTrigger asChild>
-              <Button>
-                <Plus className="mr-2 h-4 w-4" />
-                New Project
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Create Project</DialogTitle>
-                <DialogDescription>
-                  Add a new project to {organization.name}
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4 py-4">
-                <div className="space-y-2">
-                  <Label htmlFor="projectName">Project Name</Label>
-                  <Input
-                    id="projectName"
-                    placeholder="E-commerce API"
-                    value={projectName}
-                    onChange={(e) => setProjectName(e.target.value)}
-                  />
+          <div className="flex items-center gap-2">
+            {/* API Keys navigation — goes to /organizations/:orgSlug/api-keys */}
+            <Button variant="outline" asChild>
+              <Link to="/organizations/$orgSlug/api-keys" params={{ orgSlug }}>
+                <Key className="mr-2 h-4 w-4" />
+                API Keys
+              </Link>
+            </Button>
+
+            <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+              <DialogTrigger asChild>
+                <Button>
+                  <Plus className="mr-2 h-4 w-4" />
+                  New Project
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Create Project</DialogTitle>
+                  <DialogDescription>
+                    Add a new project to {organization.name}
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="projectName">Project Name</Label>
+                    <Input
+                      id="projectName"
+                      placeholder="E-commerce API"
+                      value={projectName}
+                      onChange={(e) => setProjectName(e.target.value)}
+                    />
+                  </div>
                 </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setIsCreateOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleCreateProject}
-                  disabled={createProjectMutation.isPending}
-                >
-                  {createProjectMutation.isPending ? 'Creating...' : 'Create'}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsCreateOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleCreateProject}
+                    disabled={createProjectMutation.isPending}
+                  >
+                    {createProjectMutation.isPending ? 'Creating...' : 'Create'}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
         </div>
       </div>
 
@@ -168,9 +176,9 @@ export function OrganizationDetail() {
                   <div className="flex items-start justify-between">
                     <Link
                       to="/$orgSlug/$projectSlug"
-                      params={{ 
+                      params={{
                         orgSlug: orgSlug,
-                        projectSlug: project.slug
+                        projectSlug: project.slug,
                       }}
                       className="flex-1"
                     >


### PR DESCRIPTION
## API Key Management — frontend for backend PR #65

Implements the frontend for the API key authentication system
introduced in backend PR #65. Users can create, rotate, revoke
and delete API keys directly from the organization page.

### Route

```
/organizations/:orgSlug/api-keys
```

### What's in the box

**Create flow**
- Name, description, rate limit, expiry
- Scope selector: org-wide (accesses all projects) or project-scoped
  (locked to one project, chosen from a live dropdown)
- Permission builder: dynamic rows with resource type, level, and
  optional resource ID (blank = wildcard)
- After creation: full plaintext key shown once with copy button and
  "never shown again" warning — then gone

**Table**
- Columns: name/masked key, scope, permissions, usage, rate limit,
  status, actions
- Scope badge distinguishes org-wide from project-scoped keys
- Status badges: Active / Revoked / Expired

**Rotate**
- Confirmation modal showing the current masked key
- After rotation: new plaintext key shown once

**Revoke**
- Confirmation modal; row dims immediately (optimistic update,
  rolled back on error)

**Delete**
- Requires typing the key name to enable the button

### Architecture

| Layer | Files |
|---|---|
| Types | `src/api/types.ts` |
| API client | `src/api/api-key.ts` |
| React Query hooks | `src/hooks/use-api-key.ts` |
| Base components | `KeyReveal`, `PermissionBadge` |
| Action dialogs | `RotateKeyDialog`, `RevokeKeyDialog`, `DeleteKeyDialog` |
| Create dialog | `CreateApiKeyDialog` |
| Table | `ApiKeyTable` |
| Page | `organizations/$orgSlug/api-keys/index.tsx` |

### Route change

`$orgSlug.tsx` was converted to a `index.tsx` route under `$orgSlug` 
so that `$orgSlug/index.tsx` (org detail) and
`$orgSlug/api-keys/index.tsx` (this feature) can nest under it
as siblings. The org detail page is unchanged in behaviour.

### Notes

- All key management endpoints require JWT. API keys cannot manage
  other API keys — enforced server-side and noted in the UI.

### Testing checklist

- [ ] Create an org-wide key — key reveals once, then masked
- [ ] Create a project-scoped key — scope badge shows project name
- [ ] Rotate a key — old key invalid, new key reveals once
- [ ] Revoke a key — row dims immediately, status shows Revoked
- [ ] Delete a key — name confirmation required, row removed
- [ ] Stats row counts match the list
- [ ] Empty state shown when no keys exist
- [ ] Back button returns to org detail
- [ ] Dark  Mode looks correct

 ### Known Issues
#### Light/Dark Mode Styling
- Some Tailwind classes are not applying correctly
- Likely caused by:
   - Existing global CSS overrides or
   - Tailwind config (darkMode strategy) mismatch

#### Impact:
- Certain components (badges, tiles, notices) do not render correctly in light modes

#### Next Steps:
- Audit darkMode strategy
- Check for conflicting global styles