### PR TITLE
Add pagination and infinite scrolling for organizations and records

### DIFF
--- a/src/api/organizations.ts
+++ b/src/api/organizations.ts
@@ -1,10 +1,13 @@
 import { apiClient as api } from '@/api/client';
-import type { Organization, OrganizationDetail } from '@/api/types';
+import type { Organization, OrganizationDetail, PaginatedResponse } from '@/api/types';
 import type { OrganizationInput } from '@/lib/validations';
 
 export const organizationsApi = {
-  getAll: async (): Promise<Organization[]> => {
-    const response = await api.get<Organization[]>('/organizations');
+  getAll: async (page = 0, size = 20): Promise<PaginatedResponse<Organization>> => {
+    const response = await api.get<PaginatedResponse<Organization>>('/organizations', {
+      params: { page, size }, // query params -> ?page=0&size=20
+    });
+
     return response.data;
   },
 

--- a/src/api/records.ts
+++ b/src/api/records.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { MockRecord } from './types';
+import type { MockRecord, PaginatedResponse } from './types';
 
 export const recordsApi = {
   create: async (
@@ -20,11 +20,17 @@ export const recordsApi = {
   getAll: async (
     orgSlug: string,
     projectSlug: string,
-    schemaSlug: string
-  ): Promise<MockRecord[]> => {
-    const response = await apiClient.get<MockRecord[]>(
+    schemaSlug: string,
+    page = 0,
+    size = 20
+  ): Promise<PaginatedResponse<MockRecord>> => {
+    const response = await apiClient.get<PaginatedResponse<MockRecord>>(
       `/${orgSlug}/${projectSlug}/${schemaSlug}/records`,
+      {
+        params: { page, size }, // query params -> ?page=0&size=20
+      }
     );
+
     return response.data;
   },
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -194,3 +194,11 @@ export interface RecordHealthStats {
   totalExpiredRecords: number;
   totalExpiringSoonRecords: number;
 }
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}

--- a/src/hooks/use-organizations.ts
+++ b/src/hooks/use-organizations.ts
@@ -1,12 +1,33 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { organizationsApi } from '@/api/organizations';
 import type { OrganizationInput } from '@/lib/validations';
 
-export function useOrganizations() {
+export function useOrganizations(page = 0, size = 20) {
   return useQuery({
+    queryKey: ['organizations', page, size],
+    queryFn: () => organizationsApi.getAll(page, size),
+  });
+}
+
+export function useOrganizationsInfinite(size = 20) {
+  return useInfiniteQuery({
     queryKey: ['organizations'],
-    queryFn: organizationsApi.getAll,
+
+    // called every time we fetch a page
+    queryFn: ({ pageParam = 0 }) =>
+      organizationsApi.getAll(pageParam, size),
+
+    // decides next page
+    getNextPageParam: (lastPage) => {
+      const nextPage = lastPage.page + 1;
+
+      return nextPage < lastPage.totalPages
+        ? nextPage
+        : undefined; // no more pages
+    },
+
+    initialPageParam: 0,
   });
 }
 

--- a/src/hooks/use-records.ts
+++ b/src/hooks/use-records.ts
@@ -137,6 +137,9 @@ export function useDeleteRecord(
 
     onSuccess: () => {
       queryClient.invalidateQueries({
+        queryKey: ['records', orgSlug, projectSlug, schemaSlug],
+      });
+      queryClient.invalidateQueries({
         queryKey: ['schemas', orgSlug, projectSlug, schemaSlug],
       });
       queryClient.invalidateQueries({

--- a/src/hooks/use-records.ts
+++ b/src/hooks/use-records.ts
@@ -1,6 +1,37 @@
 import { recordsApi } from '@/api/records';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export function useRecordsInfinite(
+  orgSlug: string,
+  projectSlug: string,
+  schemaSlug: string,
+  size = 20
+) {
+  return useInfiniteQuery({
+    queryKey: ['records', orgSlug, projectSlug, schemaSlug],
+
+    // fetch function (called automatically)
+    queryFn: ({ pageParam = 0 }) =>
+      recordsApi.getAll(orgSlug, projectSlug, schemaSlug, pageParam, size),
+
+    // decide next page
+    getNextPageParam: (lastPage) => {
+      const nextPage = lastPage.page + 1;
+
+      // if more pages exist → return next page
+      // else → stop infinite scroll
+      return nextPage < lastPage.totalPages
+        ? nextPage
+        : undefined;
+    },
+
+    // prevent API calls if params missing
+    enabled: !!orgSlug && !!projectSlug && !!schemaSlug,
+    initialPageParam: 0,
+  });
+}
 
 export function useRecords(
   orgSlug: string,

--- a/src/routes/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug.tsx
+++ b/src/routes/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DialogFooter, DialogHeader } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useCreateRecord, useDeleteRecord } from '@/hooks/use-records';
+import { useCreateRecord, useDeleteRecord, useRecordsInfinite } from '@/hooks/use-records';
 import { useSchema } from '@/hooks/use-schemas';
 import { formatRelativeTime } from '@/lib/utils';
 import {
@@ -22,9 +22,10 @@ import {
   Plus,
   Trash2,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useSchemaStats } from '@/hooks/use-DashboardStats';
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
 
 export const Route = createFileRoute('/_protected/_schemas/$orgSlug/$projectSlug/$schemaSlug')({
   component: SchemaDetail,
@@ -39,6 +40,41 @@ function SchemaDetail() {
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [recordData, setRecordData] = useState('{}');
+
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const {
+    data: recordsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useRecordsInfinite(orgSlug, projectSlug, schemaSlug);
+
+  const records = recordsData?.pages.flatMap((page) => page.data) ?? [];
+  
+  useEffect(() => {
+    const el = loadMoreRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+
+        // trigger when element is visible
+        if (
+          first.isIntersecting &&
+          hasNextPage &&
+          !isFetchingNextPage
+        ) {
+          fetchNextPage();    // load next page
+        }
+      },
+      { rootMargin: '200px' }  // trigger BEFORE reaching bottom
+    );
+
+    observer.observe(el);
+
+    return () => observer.unobserve(el);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const handleCreateRecord = async () => {
     try {
@@ -220,45 +256,61 @@ function SchemaDetail() {
         </CardContent>
       </Card>
 
-      {/* Recent Records */}
+      {/* All Records */}
       <Card>
         <CardHeader>
-          <CardTitle>Recent Records</CardTitle>
+          <CardTitle>All Records</CardTitle>
         </CardHeader>
+
         <CardContent>
-          {schema.recentRecords && schema.recentRecords.length > 0 ? (
-            <div className="space-y-4">
-              {schema.recentRecords.map((record) => (
-                <div key={record.id} className="border rounded-lg p-4">
-                  <div className="flex items-start justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      {record.expired ? (
-                        <span className="text-xs text-red-600">Expired</span>
-                      ) : (
-                        <CheckCircle2 className="h-4 w-4 text-green-600" />
-                      )}
-                      <span className="text-xs text-muted-foreground">
-                        ID: {record.id}
-                      </span>
+          {records.length > 0 ? (
+            <>
+              <div className="space-y-4">
+                {records.map((record) => (
+                  <div key={record.id} className="border rounded-lg p-4">
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        {record.expired ? (
+                          <span className="text-xs text-red-600">Expired</span>
+                        ) : (
+                          <CheckCircle2 className="h-4 w-4 text-green-600" />
+                        )}
+                        <span className="text-xs text-muted-foreground">
+                          ID: {record.id}
+                        </span>
+                      </div>
+
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDeleteRecord(record.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleDeleteRecord(record.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+
+                    <pre className="bg-muted p-2 rounded text-xs overflow-auto">
+                      {JSON.stringify(record.data, null, 2)}
+                    </pre>
+
+                    <p className="text-xs text-muted-foreground mt-2">
+                      Created {formatRelativeTime(record.createdAt)} • Expires{' '}
+                      {formatRelativeTime(record.expiresAt)}
+                    </p>
                   </div>
-                  <pre className="bg-muted p-2 rounded text-xs overflow-auto">
-                    {JSON.stringify(record.data, null, 2)}
-                  </pre>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Created {formatRelativeTime(record.createdAt)} • Expires{' '}
-                    {formatRelativeTime(record.expiresAt)}
-                  </p>
+                ))}
+              </div>
+
+              {/* Infinite scroll trigger */}
+              {hasNextPage && <div ref={loadMoreRef} />}
+
+              {/* Loader */}
+              {isFetchingNextPage && (
+                <div className="flex justify-center py-4">
+                  <LoadingSpinner />
                 </div>
-              ))}
-            </div>
+              )}
+            </>
           ) : (
             <div className="text-center py-8">
               <Database className="h-12 w-12 text-muted-foreground mx-auto mb-2" />

--- a/src/routes/_protected/dashboard.tsx
+++ b/src/routes/_protected/dashboard.tsx
@@ -25,11 +25,11 @@ export const Route = createFileRoute('/_protected/dashboard')({
 
 export function DashboardPage() {
   const { user } = useAuth();
-  const { data: organizations, isLoading } = useOrganizations();
+  const { data: orgResponse, isLoading } = useOrganizations();
+  const organizations = orgResponse?.data || [];
   const { data: userStats, isLoading: isUserStatsLoading, error } = useUserStats();
   console.log("User stats: ", userStats);
   console.log("Error: ", error);
-  console.log(organizations);
 
   if (isLoading || isUserStatsLoading) {
     return <LoadingSpinner fullScreen />;

--- a/src/routes/_protected/organizations/index.tsx
+++ b/src/routes/_protected/organizations/index.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
-  useOrganizations,
   useCreateOrganization,
   useDeleteOrganization,
+  useOrganizationsInfinite,
 } from '@/hooks/use-organizations';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Button } from '@/components/ui/button';
@@ -35,8 +35,49 @@ export const Route = createFileRoute('/_protected/organizations/')({
 });
 
 export function OrganizationsPage() {
-  const { data: organizations, isLoading } = useOrganizations();
-  console.log(organizations);
+  const {
+    data,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useOrganizationsInfinite();
+
+  // flatten pages
+  const organizations =
+    data?.pages.flatMap((page) => page.data) ?? [];
+
+  // observer ref
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = loadMoreRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+
+        if (
+          first.isIntersecting &&
+          hasNextPage &&
+          !isFetchingNextPage
+        ) {
+          fetchNextPage();
+        }
+      },
+      {
+        rootMargin: '200px', // preload before reaching bottom
+      }
+    );
+
+    observer.observe(el);
+
+    return () => {
+      observer.unobserve(el);
+    };
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
   const createMutation = useCreateOrganization();
   const deleteMutation = useDeleteOrganization();
 
@@ -85,14 +126,19 @@ export function OrganizationsPage() {
           Back to Dashboard
         </Button>
       </Link>
+
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Organizations</h1>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Organizations
+          </h1>
           <p className="text-muted-foreground">
             Manage your organizations and their projects
           </p>
         </div>
 
+        {/* Create Dialog */}
         <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
           <DialogTrigger asChild>
             <Button>
@@ -100,6 +146,7 @@ export function OrganizationsPage() {
               New Organization
             </Button>
           </DialogTrigger>
+
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Create Organization</DialogTitle>
@@ -107,6 +154,7 @@ export function OrganizationsPage() {
                 Add a new organization to manage your mock APIs
               </DialogDescription>
             </DialogHeader>
+
             <div className="space-y-4 py-4">
               <div className="space-y-2">
                 <Label htmlFor="name">Organization Name</Label>
@@ -118,80 +166,95 @@ export function OrganizationsPage() {
                 />
               </div>
             </div>
+
             <DialogFooter>
-              <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+              <Button
+                variant="outline"
+                onClick={() => setIsCreateOpen(false)}
+              >
                 Cancel
               </Button>
+
               <Button
                 onClick={handleCreate}
                 disabled={createMutation.isPending}
               >
-                {createMutation.isPending ? 'Creating...' : 'Create'}
+                {createMutation.isPending
+                  ? 'Creating...'
+                  : 'Create'}
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
       </div>
 
-      {isLoading ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <Card key={i}>
-              <CardHeader>
-                <Skeleton className="h-6 w-32" />
-                <Skeleton className="h-4 w-24 mt-2" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-4 w-full" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : organizations && organizations.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {organizations.map((org) => (
-            <Card key={org.id} className="relative group">
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <Link
-                    to="/organizations/$orgSlug"
-                    params={{ orgSlug: org.slug }}
-                    className="flex-1"
-                  >
-                    <CardTitle className="hover:text-primary transition-colors">
-                      {org.name}
-                    </CardTitle>
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="opacity-0 group-hover:opacity-100 transition-opacity"
-                    onClick={() => handleDelete(org.slug, org.name)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-                <CardDescription>
-                  <div className="flex items-center gap-2">
-                    <FolderKanban className="h-3 w-3" />
-                    {org.projectCount}{' '}
-                    {org.projectCount === 1 ? 'project' : 'projects'}
+      {/* List */}
+      {organizations.length > 0 ? (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {organizations.map((org) => (
+              <Card key={org.id} className="relative group">
+                <CardHeader>
+                  <div className="flex items-start justify-between">
+                    <Link
+                      to="/organizations/$orgSlug"
+                      params={{ orgSlug: org.slug }}
+                      className="flex-1"
+                    >
+                      <CardTitle className="hover:text-primary transition-colors">
+                        {org.name}
+                      </CardTitle>
+                    </Link>
+
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={() =>
+                        handleDelete(org.slug, org.name)
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   </div>
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-xs text-muted-foreground">
-                  Created {formatRelativeTime(org.createdAt)}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+
+                  <CardDescription>
+                    <div className="flex items-center gap-2">
+                      <FolderKanban className="h-3 w-3" />
+                      {org.projectCount}{' '}
+                      {org.projectCount === 1
+                        ? 'project'
+                        : 'projects'}
+                    </div>
+                  </CardDescription>
+                </CardHeader>
+
+                <CardContent>
+                  <p className="text-xs text-muted-foreground">
+                    Created {formatRelativeTime(org.createdAt)}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {/* sentinel only when more pages exist */}
+          {hasNextPage && <div ref={loadMoreRef} />}
+
+          {/* loading indicator */}
+          {isFetchingNextPage && (
+            <div className="flex justify-center py-4">
+              <LoadingSpinner />
+            </div>
+          )}
+        </>
       ) : (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-16">
             <Building2 className="h-16 w-16 text-muted-foreground mb-4" />
-            <h3 className="text-xl font-semibold mb-2">No organizations yet</h3>
+            <h3 className="text-xl font-semibold mb-2">
+              No organizations yet
+            </h3>
             <p className="text-muted-foreground text-center mb-6">
               Get started by creating your first organization
             </p>


### PR DESCRIPTION
## Description

This PR introduces pagination and infinite scrolling for organizations and mock records to improve performance and scalability.

### Changes

- Added reusable PaginatedResponse<T> type
- Refactored API layer:
    - Organizations API → paginated
    - Records API → paginated
- Replaced full data fetching with page-based fetching
- Implemented infinite scrolling using useInfiniteQuery
- Updated:
    - Organizations page → infinite scroll
    - Schema page → infinite scroll for records
- Removed dependency on recentRecords from schema response

### Why

- Prevent loading large datasets at once
- Improve UI performance and user experience
- Align frontend with backend pagination design

### How to Test
#### 1. Go to Organizations page
- Scroll → more organizations should load automatically
#### 2. Go to Schema page
- Records should load progressively on scroll
#### 3. Create/Delete records
- Ensure list updates correctly

<img width="2834" height="1534" alt="Infinite_Scrolling" src="https://github.com/user-attachments/assets/de24d272-538c-4ce2-9f61-177dc4f8306f" />


### Notes

- Default page size: 20
- Infinite scrolling stops when totalPages reached
- Uses Intersection Observer for scroll detection