### PR TITLE
feat(schema-templates): add schema template browser with API integration

### DIFF
--- a/src/api/schema-templates.ts
+++ b/src/api/schema-templates.ts
@@ -1,0 +1,24 @@
+import { apiClient } from './client';
+import type { ApplyTemplateResponse, SchemaTemplate } from './types';
+
+export const schemaTemplatesApi = {
+    // Get all system templates (metadata only, no schemaJson)
+    getSystemTemplates: async (): Promise<SchemaTemplate[]> => {
+        const response = await apiClient.get<SchemaTemplate[]>(
+            '/schema-templates/system'
+        );
+        return response.data;
+    },
+
+    // Apply a template to a specific project
+    applyTemplate: async (
+        orgSlug: string,
+        projectSlug: string,
+        templateSlug: string
+    ): Promise<ApplyTemplateResponse> => {
+        const response = await apiClient.post<ApplyTemplateResponse>(
+            `/schema-templates/${orgSlug}/${projectSlug}/${templateSlug}`
+        );
+        return response.data;
+    },
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -110,6 +110,17 @@ export interface MockSchema {
   endpointUrl: string;
 }
 
+export interface SchemaTemplate {
+  schema: {};
+  category: string | undefined;
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  schemaJson: Record<string, object>;
+  createdAt: string;
+}
+
 export interface MockSchemaDetail {
   id: string;
   name: string;
@@ -174,19 +185,6 @@ export interface OrganizationStats {
   recordCount: number;
 }
 
-export interface ProjectStats {
-  schemaCount: number;
-  recordCount: number;
-  activeRecords: number;
-  expiredRecords: number;
-}
-
-export interface SchemaStats {
-  recordCount: number;
-  activeRecords: number;
-  expiredRecords: number;
-  expiringSoonRecords: number;
-}
 
 export interface RecordHealthStats {
   totalRecords: number;
@@ -194,11 +192,10 @@ export interface RecordHealthStats {
   totalExpiredRecords: number;
   totalExpiringSoonRecords: number;
 }
-
-export interface PaginatedResponse<T> {
-  data: T[];
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
+export interface ApplyTemplateResponse {
+  schemaId: string;
+  name: string;
+  schemaSlug: string;
+  projectId: string;
+  message: string;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -185,6 +185,20 @@ export interface OrganizationStats {
   recordCount: number;
 }
 
+export interface ProjectStats {
+  schemaCount: number;
+  recordCount: number;
+  activeRecords: number;
+  expiredRecords: number;
+}
+
+export interface SchemaStats {
+  recordCount: number;
+  activeRecords: number;
+  expiredRecords: number;
+  expiringSoonRecords: number;
+}
+
 
 export interface RecordHealthStats {
   totalRecords: number;
@@ -198,4 +212,12 @@ export interface ApplyTemplateResponse {
   schemaSlug: string;
   projectId: string;
   message: string;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
 }

--- a/src/components/ui/schema-templates-Browser.tsx
+++ b/src/components/ui/schema-templates-Browser.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import { LayoutTemplate, Sparkles, Code2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useApplyTemplate, useSystemTemplates } from '@/hooks/use-schema-templates';
+import type { SchemaTemplate } from '@/api/types';
+
+interface Props {
+    orgSlug: string;
+    projectSlug: string;
+}
+
+const CATEGORY_STYLES: Record<string, string> = {
+    user: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+    product: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    ecommerce: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
+    finance: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+    blog: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+    default: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
+};
+
+function CategoryBadge({ category }: { category?: string }) {
+    const style = CATEGORY_STYLES[category?.toLowerCase() || 'default'] || CATEGORY_STYLES.default;
+    return (
+        <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${style}`}>
+            {category || 'General'}
+        </span>
+    );
+}
+
+function TemplateCard({ template, onApply, isApplying }: {
+    template: SchemaTemplate;
+    onApply: (slug: string) => void;
+    isApplying: boolean;
+}) {
+    const schemaKeys = Object.keys(template.schema || {});
+    const previewKeys = schemaKeys.slice(0, 6);
+    const hiddenCount = schemaKeys.length - previewKeys.length;
+
+    return (
+        <div className="group relative flex flex-col gap-3 rounded-xl border border-border/60 bg-card p-4 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5">
+            <div className="flex items-start justify-between gap-2">
+                <div className="flex flex-col gap-1">
+                    <span className="font-semibold text-sm text-foreground leading-tight">{template.name}</span>
+                    <CategoryBadge category={template.category} />
+                </div>
+                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Code2 className="h-4 w-4" />
+                </div>
+            </div>
+
+            {template.description && (
+                <p className="text-xs text-muted-foreground line-clamp-2">{template.description}</p>
+            )}
+
+            <div className="flex flex-wrap gap-1 mt-1">
+                {previewKeys.map((key) => (
+                    <span key={key} className="rounded-md bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+                        {key}
+                    </span>
+                ))}
+                {hiddenCount > 0 && (
+                    <span className="rounded-md bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+                        +{hiddenCount} more
+                    </span>
+                )}
+            </div>
+
+            <div className="mt-auto pt-2">
+                <Button 
+                    size="sm" 
+                    className="w-full gap-2" 
+                    onClick={() => onApply(template.slug)} 
+                    disabled={isApplying}
+                >
+                    {isApplying ? (
+                        <span className="h-3 w-3 animate-spin rounded-full border-2 border-t-transparent" />
+                    ) : (
+                        <Sparkles className="h-3.5 w-3.5" />
+                    )}
+                    Apply Template
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+export function SchemaTemplatesBrowser({ orgSlug, projectSlug }: Props) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [applyingSlug, setApplyingSlug] = useState<string | null>(null);
+
+    const { data: templates, isLoading, isError } = useSystemTemplates();
+    const applyMutation = useApplyTemplate(orgSlug, projectSlug);
+
+    const handleApply = async (slug: string) => {
+        setApplyingSlug(slug);
+        try {
+            await applyMutation.mutateAsync(slug);
+            setIsOpen(false);
+        } catch (err) {
+            console.error("Template application failed:", err);
+        } finally {
+            setApplyingSlug(null);
+        }
+    };
+
+    return (
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline" className="gap-2">
+                    <LayoutTemplate className="h-4 w-4" />
+                    Use Template
+                </Button>
+            </DialogTrigger>
+
+            <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <LayoutTemplate className="h-5 w-5 text-primary" />
+                        Schema Templates
+                    </DialogTitle>
+                    <DialogDescription>
+                        Select a pre-defined template to quickly bootstrap your project schema.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex-1 overflow-y-auto mt-4 pr-1">
+                    {isLoading ? (
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {[...Array(6)].map((_, i) => (
+                                <Skeleton key={i} className="h-44 w-full rounded-xl" />
+                            ))}
+                        </div>
+                    ) : isError ? (
+                        <div className="text-center py-12">
+                            <p className="text-sm text-muted-foreground">Failed to load templates. Please try again.</p>
+                        </div>
+                    ) : (
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {templates?.map(tpl => (
+                                <TemplateCard
+                                    key={tpl.id}
+                                    template={tpl}
+                                    onApply={handleApply}
+                                    isApplying={applyingSlug === tpl.slug && applyMutation.isPending}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/hooks/use-DashboardStats.ts
+++ b/src/hooks/use-DashboardStats.ts
@@ -17,7 +17,7 @@ export const useOrganizationStats = (orgId: string) => {
     });
 };
 
-export const useProjectStats = (projectId: string) => {
+export const useProjectStats = (projectId: string | undefined) => {
     return useQuery({
         queryKey: ['dashboard', 'project', projectId],
         queryFn: () => dashboardApi.getProjectStats(projectId),

--- a/src/hooks/use-schema-templates.ts
+++ b/src/hooks/use-schema-templates.ts
@@ -1,0 +1,43 @@
+import { schemaTemplatesApi } from '@/api/schema-templates';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+// Fetch all system templates
+export function useSystemTemplates() {
+  return useQuery({
+    queryKey: ['schema-templates', 'system'],
+    queryFn: schemaTemplatesApi.getSystemTemplates,
+    staleTime: 5 * 60 * 1000, // cache for 5 mins
+  });
+}
+
+// Apply template to a project
+export function useApplyTemplate(orgSlug: string, projectSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (templateSlug: string) =>
+      schemaTemplatesApi.applyTemplate(orgSlug, projectSlug, templateSlug),
+
+    onSuccess: (data) => {
+      toast.success(`Schema "${data.name}" created`);
+
+      // refresh related data after mutation
+      queryClient.invalidateQueries({
+        queryKey: ['projects', orgSlug, projectSlug],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['schemas', orgSlug, projectSlug],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard'],
+      });
+    },
+
+    onError: (error: any) => {
+      toast.error(
+        error?.response?.data?.message || 'Failed to apply template'
+      );
+    },
+  });
+}

--- a/src/routes/_protected/_projects/$orgSlug/$projectSlug.tsx
+++ b/src/routes/_protected/_projects/$orgSlug/$projectSlug.tsx
@@ -34,6 +34,7 @@ import {
 import { toast } from 'sonner';
 import { formatRelativeTime } from '@/lib/utils';
 import { useProjectStats } from '@/hooks/use-DashboardStats';
+import { SchemaTemplatesBrowser } from '@/components/ui/schema-templates-Browser';
 
 export const Route = createFileRoute('/_protected/_projects/$orgSlug/$projectSlug')({
   component: ProjectDetail,
@@ -143,7 +144,9 @@ function ProjectDetail() {
             </p>
           </div>
 
-          <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+          <div className="flex items-center gap-2">
+            <SchemaTemplatesBrowser orgSlug={orgSlug} projectSlug={projectSlug} />
+            <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
             <DialogTrigger asChild>
               <Button>
                 <Plus className="mr-2 h-4 w-4" />
@@ -196,6 +199,7 @@ function ProjectDetail() {
               </DialogFooter>
             </DialogContent>
           </Dialog>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## 🚀 Feature: Schema Templates Browser

### Problem
Creating mock schemas manually for each project caused duplication and inconsistency.
There was no reusable system for sharing schema definitions across projects.

### Solution
Implemented a schema templates system with a browser UI to explore and apply templates.

### Changes
- Added schema templates API layer
- Created React Query hooks for templates
- Built schema templates browser UI
- Integrated template application into project route
- Updated related types and hooks

### Impact
- Faster project setup
- Reusable schema definitions
- Improved developer experience

### Future Improvements
- Add template preview
- Add custom template creation