### PR TITLE
Implemented OpenAPI specification import support in the Mockify frontend

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -1,0 +1,17 @@
+import { apiClient as api } from "./client";
+import type { OpenApiImportResponse } from "./types";
+
+export const OpenApi = {
+  import: async (
+    orgSlug: string,
+    projectSlug: string,
+    file: File,
+  ): Promise<OpenApiImportResponse> => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    return api.post(`${orgSlug}/${projectSlug}/import/openapi`,
+        formData
+    );
+  },
+};

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -10,8 +10,11 @@ export const OpenApi = {
     const formData = new FormData();
     formData.append("file", file);
 
-    return api.post(`${orgSlug}/${projectSlug}/import/openapi`,
-        formData
+    const { data } = await api.post<OpenApiImportResponse>(
+    `${orgSlug}/${projectSlug}/import/openapi`,
+    formData
     );
+
+    return data;
   },
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -349,3 +349,30 @@ export interface InvitationResponse {
   expiresAt: string;
   createdAt: string;
 }
+
+
+// Open API types
+export interface OpenApiImportResponse {
+  imported: ImportedSchema[];
+  skipped: SkippedComponent[];
+  totalImported: number;
+  totalSkipped: number;
+}
+
+export interface ImportedSchema {
+  id: string;
+  name: string;
+  slug: string;
+  projectId: string;
+  projectName: string;
+  schemaJson: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  recordCount: number;
+  endpointUrl: string;
+}
+
+export interface SkippedComponent {
+  component: string;
+  reason: string;
+}

--- a/src/components/ui/import-openapi-dialog.tsx
+++ b/src/components/ui/import-openapi-dialog.tsx
@@ -1,0 +1,255 @@
+import { useRef, useState } from 'react';
+import { Upload, FileText, X, ChevronDown, ChevronUp, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { useImportOpenApi } from '@/hooks/use-open-api';
+import type { OpenApiImportResponse, SkippedComponent } from '@/api/types';
+
+interface ImportOpenApiDialogProps {
+  orgSlug: string;
+  projectSlug: string;
+}
+
+export function ImportOpenApiDialog({ orgSlug, projectSlug }: ImportOpenApiDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [importResult, setImportResult] = useState<OpenApiImportResponse | null>(null);
+  const [isSkippedExpanded, setIsSkippedExpanded] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const importMutation = useImportOpenApi();
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      // Reset state on close
+      setSelectedFile(null);
+      setImportResult(null);
+      setIsSkippedExpanded(false);
+    }
+  };
+
+  const handleFileSelect = (file: File) => {
+    const validTypes = ['.yml', '.yaml', '.json'];
+    const isValid = validTypes.some((ext) => file.name.toLowerCase().endsWith(ext));
+    if (!isValid) return;
+    setSelectedFile(file);
+    setImportResult(null);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = () => setIsDragging(false);
+
+  const handleImport = async () => {
+    if (!selectedFile) return;
+    const result = await importMutation.mutateAsync({ file: selectedFile, orgSlug, projectSlug });
+    setImportResult(result);
+  };
+
+  const handleClearFile = () => {
+    setSelectedFile(null);
+    setImportResult(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const hasResult = importResult !== null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Upload className="mr-2 h-4 w-4" />
+          Import OpenAPI
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import OpenAPI Spec</DialogTitle>
+          <DialogDescription>
+            Upload a <code className="text-xs bg-muted px-1 py-0.5 rounded">.yml</code>,{' '}
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">.yaml</code>, or{' '}
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">.json</code> OpenAPI file.
+            Each component schema will become a Mockify schema.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {!hasResult ? (
+            <>
+              {/* Drop zone */}
+              <div
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onClick={() => !selectedFile && fileInputRef.current?.click()}
+                className={`
+                  relative border-2 border-dashed rounded-lg transition-colors
+                  ${isDragging ? 'border-primary bg-primary/5' : 'border-muted-foreground/25 hover:border-muted-foreground/50'}
+                  ${selectedFile ? 'cursor-default' : 'cursor-pointer'}
+                  p-6
+                `}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".yml,.yaml,.json"
+                  className="hidden"
+                  onChange={handleInputChange}
+                />
+
+                {selectedFile ? (
+                  <div className="flex items-center gap-3">
+                    <FileText className="h-8 w-8 text-primary shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">{selectedFile.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {(selectedFile.size / 1024).toFixed(1)} KB
+                      </p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleClearFile();
+                      }}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center gap-2 text-center">
+                    <Upload className="h-8 w-8 text-muted-foreground" />
+                    <div>
+                      <p className="text-sm font-medium">Drop your file here</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        or click to browse
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            /* Result summary */
+            <ImportResultSummary
+              result={importResult}
+              isSkippedExpanded={isSkippedExpanded}
+              onToggleSkipped={() => setIsSkippedExpanded((v) => !v)}
+            />
+          )}
+        </div>
+
+        <DialogFooter>
+          {!hasResult ? (
+            <>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleImport}
+                disabled={!selectedFile || importMutation.isPending}
+              >
+                {importMutation.isPending ? 'Importing…' : 'Import'}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={() => handleOpenChange(false)}>Done</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Result Summary ────────────────────────────────────────────────────────────
+
+interface ImportResultSummaryProps {
+  result: OpenApiImportResponse;
+  isSkippedExpanded: boolean;
+  onToggleSkipped: () => void;
+}
+
+function ImportResultSummary({ result, isSkippedExpanded, onToggleSkipped }: ImportResultSummaryProps) {
+  const { totalImported, totalSkipped, skipped } = result;
+
+  return (
+    <div className="space-y-3">
+      {/* Imported count */}
+      <div className="flex items-center gap-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-900 px-4 py-3">
+        <div className="h-2 w-2 rounded-full bg-green-500 shrink-0" />
+        <p className="text-sm font-medium text-green-800 dark:text-green-300">
+          {totalImported} schema{totalImported !== 1 ? 's' : ''} imported successfully
+        </p>
+      </div>
+
+      {/* Skipped (if any) */}
+      {totalSkipped > 0 && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-900 overflow-hidden">
+          <button
+            className="w-full flex items-center justify-between gap-3 px-4 py-3 bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100 dark:hover:bg-amber-950/50 transition-colors text-left"
+            onClick={onToggleSkipped}
+          >
+            <div className="flex items-center gap-3">
+              <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                {totalSkipped} component{totalSkipped !== 1 ? 's' : ''} skipped
+              </p>
+            </div>
+            {isSkippedExpanded ? (
+              <ChevronUp className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
+            )}
+          </button>
+
+          {isSkippedExpanded && (
+            <SkippedList items={skipped} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SkippedList({ items }: { items: SkippedComponent[] }) {
+  return (
+    <ul className="divide-y divide-border max-h-48 overflow-y-auto">
+      {items.map((item, i) => (
+        <li key={i} className="px-4 py-2.5 flex items-start gap-3">
+          <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono mt-0.5 shrink-0">
+            {item.component}
+          </code>
+          <span className="text-xs text-muted-foreground">{item.reason}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui/import-openapi-dialog.tsx
+++ b/src/components/ui/import-openapi-dialog.tsx
@@ -11,7 +11,8 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { useImportOpenApi } from '@/hooks/use-open-api';
-import type { OpenApiImportResponse, SkippedComponent } from '@/api/types';
+import type { ImportedSchema, OpenApiImportResponse, SkippedComponent } from '@/api/types';
+import { toast } from 'sonner';
 
 interface ImportOpenApiDialogProps {
   orgSlug: string;
@@ -24,7 +25,9 @@ export function ImportOpenApiDialog({ orgSlug, projectSlug }: ImportOpenApiDialo
   const [isDragging, setIsDragging] = useState(false);
   const [importResult, setImportResult] = useState<OpenApiImportResponse | null>(null);
   const [isSkippedExpanded, setIsSkippedExpanded] = useState(false);
+  const [isImportedExpanded, setIsImportedExpanded] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
 
   const importMutation = useImportOpenApi();
 
@@ -39,9 +42,23 @@ export function ImportOpenApiDialog({ orgSlug, projectSlug }: ImportOpenApiDialo
   };
 
   const handleFileSelect = (file: File) => {
+
+    const MAX_SIZE = 2 * 1024 * 1024;
     const validTypes = ['.yml', '.yaml', '.json'];
     const isValid = validTypes.some((ext) => file.name.toLowerCase().endsWith(ext));
-    if (!isValid) return;
+
+    if (file.size > MAX_SIZE) {
+        toast.error("Maximum file size is 2 MB.");
+        return;
+    }
+
+    if (!isValid) {
+        toast.error(
+            "Please select a .yml, .yaml or .json OpenAPI file."
+        );
+        return;
+    }
+    
     setSelectedFile(file);
     setImportResult(null);
   };
@@ -67,8 +84,17 @@ export function ImportOpenApiDialog({ orgSlug, projectSlug }: ImportOpenApiDialo
 
   const handleImport = async () => {
     if (!selectedFile) return;
-    const result = await importMutation.mutateAsync({ file: selectedFile, orgSlug, projectSlug });
-    setImportResult(result);
+    try {
+        const result = await importMutation.mutateAsync({
+            file: selectedFile,
+            orgSlug,
+            projectSlug,
+        });
+
+        setImportResult(result);
+    } catch {
+        // Toast is already handled by the hook if you add onError there.
+    }
   };
 
   const handleClearFile = () => {
@@ -160,9 +186,15 @@ export function ImportOpenApiDialog({ orgSlug, projectSlug }: ImportOpenApiDialo
           ) : (
             /* Result summary */
             <ImportResultSummary
-              result={importResult}
-              isSkippedExpanded={isSkippedExpanded}
-              onToggleSkipped={() => setIsSkippedExpanded((v) => !v)}
+                result={importResult}
+                isImportedExpanded={isImportedExpanded}
+                isSkippedExpanded={isSkippedExpanded}
+                onToggleImported={() =>
+                    setIsImportedExpanded(v => !v)
+                }
+                onToggleSkipped={() =>
+                    setIsSkippedExpanded(v => !v)
+                }
             />
           )}
         </div>
@@ -193,22 +225,48 @@ export function ImportOpenApiDialog({ orgSlug, projectSlug }: ImportOpenApiDialo
 
 interface ImportResultSummaryProps {
   result: OpenApiImportResponse;
+  isImportedExpanded: boolean;
   isSkippedExpanded: boolean;
+  onToggleImported: () => void;
   onToggleSkipped: () => void;
 }
 
-function ImportResultSummary({ result, isSkippedExpanded, onToggleSkipped }: ImportResultSummaryProps) {
-  const { totalImported, totalSkipped, skipped } = result;
+function ImportResultSummary({
+    result,
+    isImportedExpanded,
+    isSkippedExpanded,
+    onToggleImported,
+    onToggleSkipped,
+}: ImportResultSummaryProps) {
+  const {imported, skipped, totalImported, totalSkipped,} = result;
 
   return (
     <div className="space-y-3">
-      {/* Imported count */}
-      <div className="flex items-center gap-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-900 px-4 py-3">
-        <div className="h-2 w-2 rounded-full bg-green-500 shrink-0" />
-        <p className="text-sm font-medium text-green-800 dark:text-green-300">
-          {totalImported} schema{totalImported !== 1 ? 's' : ''} imported successfully
-        </p>
-      </div>
+
+        {/* Imported count */}
+        <div className="rounded-lg border border-green-200 dark:border-green-900 overflow-hidden">
+        <button
+            className="w-full flex items-center justify-between px-4 py-3 bg-green-50 dark:bg-green-950/30"
+            onClick={onToggleImported}
+        >
+            <div className="flex items-center gap-3">
+            <div className="h-2 w-2 rounded-full bg-green-500" />
+            <p className="text-sm font-medium">
+                {totalImported} schema{totalImported !== 1 ? "s" : ""} imported successfully
+            </p>
+            </div>
+
+            {isImportedExpanded ? (
+            <ChevronUp className="h-4 w-4" />
+            ) : (
+            <ChevronDown className="h-4 w-4" />
+            )}
+        </button>
+
+        {isImportedExpanded && (
+            <ImportedList items={imported} />
+        )}
+        </div>
 
       {/* Skipped (if any) */}
       {totalSkipped > 0 && (
@@ -236,6 +294,27 @@ function ImportResultSummary({ result, isSkippedExpanded, onToggleSkipped }: Imp
         </div>
       )}
     </div>
+  );
+}
+
+interface ImportedListProps {
+  items: ImportedSchema[];
+}
+
+function ImportedList({ items }: ImportedListProps) {
+  return (
+    <ul className="divide-y divide-border max-h-48 overflow-y-auto">
+      {items.map((item) => (
+        <li
+          key={item.id}
+          className="px-4 py-2.5 flex items-center gap-3"
+        >
+          <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+            {item.name}
+          </code>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/hooks/use-open-api.ts
+++ b/src/hooks/use-open-api.ts
@@ -1,0 +1,35 @@
+import { OpenApi } from "@/api/openapi";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface ImportParams {
+    file: File;
+    orgSlug: string;
+    projectSlug: string;
+}
+
+export function useImportOpenApi() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ file, orgSlug, projectSlug }: ImportParams) =>
+        OpenApi.import(orgSlug, projectSlug, file),
+
+        onSuccess: (response, variables) => {
+        const { orgSlug, projectSlug } = variables;
+
+        // Refresh project and schema details
+        queryClient.invalidateQueries({queryKey: ['schemas', orgSlug, projectSlug],});
+        queryClient.invalidateQueries({queryKey: ['projects', orgSlug, projectSlug],});
+
+        // Refresh dashboard stats that might be affected by the new schemas
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
+        queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']}); 
+
+        toast.success(
+            `Imported ${response.totalImported} schema${response.totalImported === 1 ? "" : "s"}`
+        );
+        },
+    });
+}

--- a/src/hooks/use-open-api.ts
+++ b/src/hooks/use-open-api.ts
@@ -1,3 +1,4 @@
+import { handleApiError } from "@/api/client";
 import { OpenApi } from "@/api/openapi";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -16,20 +17,24 @@ export function useImportOpenApi() {
         OpenApi.import(orgSlug, projectSlug, file),
 
         onSuccess: (response, variables) => {
-        const { orgSlug, projectSlug } = variables;
+            const { orgSlug, projectSlug } = variables;
 
-        // Refresh project and schema details
-        queryClient.invalidateQueries({queryKey: ['schemas', orgSlug, projectSlug],});
-        queryClient.invalidateQueries({queryKey: ['projects', orgSlug, projectSlug],});
+            // Refresh project and schema details
+            queryClient.invalidateQueries({queryKey: ['schemas', orgSlug, projectSlug],});
+            queryClient.invalidateQueries({queryKey: ['projects', orgSlug, projectSlug],});
 
-        // Refresh dashboard stats that might be affected by the new schemas
-        queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
-        queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
-        queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']}); 
+            // Refresh dashboard stats that might be affected by the new schemas
+            queryClient.invalidateQueries({queryKey: ['dashboard', 'user']});
+            queryClient.invalidateQueries({queryKey: ['dashboard', 'project']}); 
+            queryClient.invalidateQueries({queryKey: ['dashboard', 'schema']}); 
 
-        toast.success(
-            `Imported ${response.totalImported} schema${response.totalImported === 1 ? "" : "s"}`
-        );
+            toast.success(
+                `Imported ${response.totalImported} schema${response.totalImported === 1 ? "" : "s"}`
+            );
+        },
+
+        onError: (error) => {
+            toast.error(handleApiError(error));
         },
     });
 }

--- a/src/routes/_protected/_projects/$orgSlug/$projectSlug.tsx
+++ b/src/routes/_protected/_projects/$orgSlug/$projectSlug.tsx
@@ -35,6 +35,7 @@ import { toast } from 'sonner';
 import { formatRelativeTime } from '@/lib/utils';
 import { useProjectStats } from '@/hooks/use-DashboardStats';
 import { SchemaTemplatesBrowser } from '@/components/ui/schema-templates-Browser';
+import { ImportOpenApiDialog } from '@/components/ui/import-openapi-dialog';
 
 export const Route = createFileRoute('/_protected/_projects/$orgSlug/$projectSlug')({
   component: ProjectDetail,
@@ -145,7 +146,11 @@ function ProjectDetail() {
           </div>
 
           <div className="flex items-center gap-2">
+
             <SchemaTemplatesBrowser orgSlug={orgSlug} projectSlug={projectSlug} />
+
+            <ImportOpenApiDialog orgSlug={orgSlug} projectSlug={projectSlug} />
+
             <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
             <DialogTrigger asChild>
               <Button>


### PR DESCRIPTION
## Summary

Implemented OpenAPI specification import support in the Mockify frontend, allowing users to upload existing OpenAPI YAML/JSON files and automatically generate Mockify schemas inside a project.

This integrates the existing backend OpenAPI import API with a complete frontend workflow including file upload, validation, import status handling, and detailed import results.

## Changes

### API Integration

- Added OpenAPI import API client
- Added multipart file upload support using `FormData`
- Integrated with backend endpoint:
  - `POST /api/{org}/{project}/import/openapi`
- Added typed response handling for imported schemas and skipped components
- Updated API layer to return response data directly

### React Query Integration

- Added `useImportOpenApi` mutation hook
- Added automatic cache invalidation after successful imports:
  - Project details
  - Schema list
  - Dashboard statistics
- Added success notifications after imports
- Added centralized API error handling through mutation errors

### OpenAPI Import Dialog

- Added reusable `ImportOpenApiDialog` component
- Added project page integration alongside schema creation actions
- Implemented drag-and-drop file upload
- Added manual file selection support
- Added selected file preview:
  - File name
  - File size
  - Clear selected file action

### File Validation

Added client-side validation before uploading:

- Allow only supported OpenAPI formats:
  - `.yaml`
  - `.yml`
  - `.json`
- Added maximum upload size validation
- Added user feedback for invalid files

### Import Result Summary

Added detailed post-import feedback:

- Show total imported schemas
- Show imported schema names
- Show skipped component count
- Show skipped component details:
  - Component name
  - Skip reason
- Added expandable sections for better readability

### UX Improvements

- Added loading state while importing
- Disabled import action during upload
- Added toast notifications
- Reset dialog state after closing
- Improved visual feedback for drag-and-drop interactions

## Testing

Tested the following scenarios:

- Import valid OpenAPI YAML specification
- Import valid OpenAPI JSON specification
- Reject unsupported file extensions
- Reject files exceeding size limit
- Display successfully imported schemas
- Display skipped schemas with reasons
- Verify project schema list refreshes after import
- Verify dashboard/project statistics update after import
- Verify API errors display correctly

## Screenshots / Demo
- Import OpenAPI button on project page
<img width="2110" height="1234" alt="Import_Icon" src="https://github.com/user-attachments/assets/c0647108-f5fd-43ed-9f21-47dd1c4d5942" />

- Upload dialog
<img width="1018" height="656" alt="Import_Diolog" src="https://github.com/user-attachments/assets/c1bb325f-84a1-476c-9ecc-bc0f6ff7a2a8" />

- Successful import summary
<img width="1310" height="1278" alt="Import_Results" src="https://github.com/user-attachments/assets/73ee80cf-aa9d-4a4a-b44b-cfce8291560c" />

## Related Backend Feature

Requires backend OpenAPI import endpoint:

`POST /api/{org}/{project}/import/openapi`