### PR TITLE
Refactor OAuth2 Redirect Flow for Secure Token Handling & Fix Toast Bug

### DIFF
--- a/src/routes/oauth2/redirect.tsx
+++ b/src/routes/oauth2/redirect.tsx
@@ -1,17 +1,18 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute, redirect, isRedirect } from '@tanstack/react-router';
 import { authApi } from '@/api/auth';
 import { CURRENT_USER_KEY } from '@/hooks/use-auth';
 import { toast } from 'sonner';
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
+import { tokenStore } from '@/api/token';
 
 export const Route = createFileRoute('/oauth2/redirect')({
   validateSearch: (search: Record<string, any>) => ({
-    access_token: search.access_token as string | undefined,
+    status: search.status as string | undefined,
     error: search.error as string | undefined,
   }),
 
   beforeLoad: async ({ search, context }) => {
-    const { access_token, error } = search;
+    const { status, error } = search;
     const { queryClient } = context;
 
     if (error) {
@@ -19,21 +20,30 @@ export const Route = createFileRoute('/oauth2/redirect')({
       throw redirect({ to: '/login' });
     }
 
-    if (!access_token) {
-      toast.error('No access token received');
+    if (status !== 'success') {
+      toast.error('Invalid authentication response');
       throw redirect({ to: '/login' });
     }
 
-    // Save token
-    localStorage.setItem('accessToken', access_token);
+    try {
+      const { access_token } = await authApi.refresh();
+      tokenStore.set(access_token);
 
-    // Fetch user using the token
-    const user = await authApi.getCurrentUser();
-    queryClient.setQueryData(CURRENT_USER_KEY, user);
+      const user = await authApi.getCurrentUser();
+      queryClient.setQueryData(CURRENT_USER_KEY, user);
 
-    toast.success('Successfully signed in with Google');
+      toast.success('Successfully signed in with Google');
+      throw redirect({ to: '/dashboard' });
 
-    throw redirect({ to: '/dashboard' });
+    } catch (err) {
+      if (isRedirect(err)) {
+        throw err;
+      }
+
+      console.error('OAuth token exchange failed:', err);
+      toast.error('Failed to complete secure authentication');
+      throw redirect({ to: '/login' });
+    }
   },
 
   component: OAuth2RedirectPage,


### PR DESCRIPTION
### Overview

This PR updates our frontend OAuth2 redirect page to align with the new, highly secure backend implementation. It also fixes a minor UX bug where TanStack Router was triggering false error toasts during a successful login.

### What Changed?

#### Security & Auth Updates

* **No more tokens in the URL:** Stopped extracting the `access_token` from URL search parameters to prevent token leakage in browser history.
* **HttpOnly Cookie Flow:** Updated the route to expect a safe `status=success` flag from the backend.
* **Explicit Refresh:** The redirect page now immediately calls `authApi.refresh()` to securely fetch the access token using the HttpOnly cookie provided by the backend.
* **Token Storage:** Migrated to using the centralized `tokenStore` to save the newly fetched access token.

#### Bug Fixes

* **Fixed "Double Toast" Bug:** Added a check for `isRedirect(err)` inside the `try...catch` block. This prevents TanStack Router's intentional redirect exceptions from being mistakenly caught as errors, which previously caused a "Failed to complete secure authentication" toast to appear even on successful logins.